### PR TITLE
Needs explicit casting for ulong -> int.

### DIFF
--- a/source/vibe/templ/diet.d
+++ b/source/vibe/templ/diet.d
@@ -744,7 +744,7 @@ private int indentLevel(string s, string indent)
 	int l = 0;
 	while( l+indent.length <= s.length && s[l .. l+indent.length] == indent )
 		l += indent.length;
-	return l / indent.length;
+	return cast(int)(l / indent.length);
 }
 
 private int indentLevel(in Line[] ln, string indent)


### PR DESCRIPTION
Related to #3, fixes for changeset d7ac37bf80270d11560c7d322cacc9703018464b
