### PR TITLE
Exit vpm nicer

### DIFF
--- a/bin/vpm.d
+++ b/bin/vpm.d
@@ -6,6 +6,7 @@
 	Authors: Matthias Dondorff
 */
 import std.file;
+import std.c.stdlib;
 
 import vibe.d;
 import vibe.core.log;
@@ -33,7 +34,6 @@ static this() {
 	//vpm.createZip("testApp.zip");
 
 
-	// TODO: way to quit vibe needed
-	throw new Exception("quit vibe");
+	exit(0);
 }
 


### PR DESCRIPTION
Use `exit(0)` instead of `throw new Exception("quit vibe")`
