### PR TITLE
Updated Homebrew install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you don't have brew installed, install it according to their [install
 instructions](<https://github.com/mxcl/homebrew/wiki/installation>) and
 install libevent.
 
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.github.com/gist/323731)"
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/master/Library/Contributions/install_homebrew.rb)"
     brew install libevent
 
 (Note: Install brew only if you do not have macports, as they will conflict)


### PR DESCRIPTION
The script has been moved to the main homebrew repository, and using the Gist
no longer works, as its contents have been replaced.
