### PR TITLE
lolfix

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -721,6 +721,7 @@ void deserializeBson(T)(ref T dst, Bson src)
 			}
 		}
 	} else static if( is(T == class) ){
+		if (src.isNull()) return;
 		dst = new T;
 		foreach( m; __traits(allMembers, T) ){
 			static if( isRWPlainField!(T, m) ){


### PR DESCRIPTION
- deserializeBson() now correctyl handles null pointers, aka Type.Null bson objects
