### PR TITLE
Pass exception msg to assert when call to log() fails. 

### DIFF
--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -97,7 +97,7 @@ nothrow {
 		}
 	} catch( Exception e ){
 		// this is bad but what can we do..
-		debug assert(false);
+		debug assert(false, e.msg);
 	}
 }
 


### PR DESCRIPTION
I ran into a problem where I was passing bad data to a logInfo call. I saw that an assert was occurring but couldn't tell why. Once I added the exception's msg property to the assert I was able to get the error indicating the problem (which was an invalid Bson type). 

So, a very small change but one that I found useful. 
