### PR TITLE
Fix compile error(DMD64 v2.060)

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -92,7 +92,7 @@ struct NetworkAddress {
 	*/
 	@property ushort family() const { return addr.sa_family; }
 	/// ditto
-	@property void family(ushort val) { addr.sa_family = val; }
+	@property void family(ushort val) { addr.sa_family = cast(ubyte)val; }
 
 	/** The port in host byte order.
 	*/


### PR DESCRIPTION
I do not understand it well.
but i can run example programs with this commit.

I'm sorry for my poor English. :-(
## error message

/source/vibe/core/net.d(95): Error: cannot implicitly convert expression (val) of type ushort to ubyte

$ dmd -v
DMD64 D Compiler v2.060
