### PR TITLE
Fix for markdown filter line breaking

### DIFF
--- a/source/vibe/textfilter/markdown.d
+++ b/source/vibe/textfilter/markdown.d
@@ -501,7 +501,7 @@ private void writeMarkdownEscaped(R)(ref R dst, string ln, in LinkRef[string] li
 				break;
 		}
 	}
-	if( br ) dst.put("<br>");
+	if( br ) dst.put("<br/>");
 }
 
 private void outputHeaderLine(R)(ref R dst, string ln, string hln)


### PR DESCRIPTION
Markdown implementation didn't close <br> tag for line breaking, which led to non-valid xhtml output.
