### PR TITLE
Helper functions for Json.

### DIFF
--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -97,6 +97,18 @@ struct Json {
 	this(Json[] v) { m_type = Type.Array; m_array = v; }
 	/// ditto
 	this(Json[string] v) { m_type = Type.Object; m_object = v; }
+	/// ditto
+	this(Type type) { m_type = type; }
+
+	/**
+		Helper function to construct an empty object,
+		equivalent of javascript {}
+	*/
+
+	static Json emptyObject()
+	{
+		return Json(Type.Object);
+	}
 
 	/**
 		Allows assignment of D values to a JSON value.


### PR DESCRIPTION
Currently in Vibe's Json implementation there is no easy way to do an equivalent of the following JavaScript code

``` javascript
var x = {};
```

You can workaround this by doing something like

``` d
Json[string] empty;
auto x = Json(empty);
```

The pull request adds a constructor that takes a type(which is useful on its own) as well as a helper function to make an empty object.
