### PR TITLE
WebSocket.connected to call TcpConnection.connected

### DIFF
--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -29,6 +29,7 @@ module vibe.http.websockets;
 import vibe.http.server;
 import vibe.crypto.sha1;
 import vibe.core.log;
+import vibe.core.net;
 
 import std.conv;
 import std.array;
@@ -214,15 +215,16 @@ class IncommingWebSocketMessage : InputStream {
 
 class WebSocket {
 	private {
-		Stream m_conn;
+		TcpConnection m_conn;
 	}
 
 	this(Stream conn)
 	{
-		m_conn = conn;
+		m_conn = cast(TcpConnection)conn;
+		assert(m_conn);
 	}
 
-	@property bool connected() { return !m_conn.empty; }
+	@property bool connected() { return m_conn.connected; }
 	@property bool dataAvailableForRead() { return m_conn.dataAvailableForRead; }
 
 	void send(ubyte[] data)


### PR DESCRIPTION
As discussed in the [forums](http://news.rejectedsoftware.com/groups/rejectedsoftware.vibed/thread/512/) `WebSocket.connected`method currently calls `TcpConnection.empty` method, which means that it will only return when there is new data coming and we cannot for example send data to the socket.

Changing it to call `TcpConnection.connected()` instead fixes the problem. However we have to downcast the `Stream` reference to `TcpConnection` to that - I am not sure if that's good but seems sensible to me - Websockets actually require not just a stream but a socket.
