### PR TITLE
Carriage Return instead of Newline in the start script errors out on Linux

### DIFF
--- a/bin/vpm.d
+++ b/bin/vpm.d
@@ -137,8 +137,10 @@ int main(string[] args)
 				flags ~= getPackagesAsVersion(vpm);
 				flags ~= (Path("source") ~ appName).toNativeString();
 				flags ~= args[1 .. $];
-
-				appStartScript = "rdmd " ~ getDflags() ~ " " ~ join(flags, " ") ~ "\r\n";
+                version(Windows)
+                    appStartScript = "rdmd" ~ getDflags() ~ " " ~ join(flags, " ") ~ "\r\n";
+                version(Posix)
+				    appStartScript = "rdmd " ~ getDflags() ~ " " ~ join(flags, " ") ~ "\n";
 				if( del_exe_file.length ) appStartScript ~= "del \""~del_exe_file~"\"";
 				break;
 			case "upgrade":


### PR DESCRIPTION
Maybe there's a better way of doing this, but I don't have a windows machine to test.
