### PR TITLE
redis.ttl fix for expired keys. + potential implementation of redis.zrangebyscore

### DIFF
--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -432,7 +432,18 @@ final class RedisClient {
 		return request("ZRANGE", args);
 	}
 
-	//TODO: zrangeByScore
+	RedisReply zrangeByScore(string key, size_t start, size_t end, bool withScores=false) {
+		ubyte[][] args = [cast(ubyte[])key, cast(ubyte[])to!string(start), cast(ubyte[])to!string(end)];
+		if (withScores) args ~= cast(ubyte[])"WITHSCORES";
+		return request("ZRANGEBYSCORE", args);
+	}
+
+	RedisReply zrangeByScore(string key, size_t start, size_t end, size_t offset, size_t count, bool withScores=false) {
+		ubyte[][] args = [cast(ubyte[])key, cast(ubyte[])to!string(start), cast(ubyte[])to!string(end)];
+		if (withScores) args ~= cast(ubyte[])"WITHSCORES";
+                args ~= cast(ubyte[])"LIMIT" ~ cast(ubyte[])to!string(offset) ~ cast(ubyte[])to!string(count);
+		return request("ZRANGEBYSCORE", args);
+	}
 
 	int zrank(string key, string member) {
 		auto str = request!string("ZRANK", cast(ubyte[]) key, cast(ubyte[]) member);


### PR DESCRIPTION
changed return type of redis.ttl from size_t(ulong) to long, since it returns -1 for expired keys

also included a potential implementation of redis.zrangebyscore covering all arguments with 2 functions.
