### PR TITLE
ensure void body is quick in keep-alive connections

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -590,8 +590,13 @@ final class HttpServerResponse : HttpResponse {
 		writeBody(cast(ubyte[])serializeToJson(data).toString(), "application/json");
 	}
 
-	/** Writes the response with no body.
-	*/
+	/**
+	 * Writes the response with no body.
+	 * 
+	 * This method should be used in situations where no body is
+	 * requested, such as a HEAD request. For an empty body, just use writeBody,
+	 * as this method causes problems with some keep-alive connections.
+	 */
 	void writeVoidBody()
 	{
 		if( !m_isHeadResponse ){
@@ -599,7 +604,6 @@ final class HttpServerResponse : HttpResponse {
 			assert("Transfer-Encoding" !in headers);
 		}
 		assert(!headerWritten);
-		headers["Content-Length"] = "0";
 		writeHeader();
 	}
 


### PR DESCRIPTION
Writing a void body, when the connection is keep-alive, there is no way for the client to tell when the body is done without a content-length, so it takes 10 seconds.

This pull request fixes that.
