### PR TITLE
Enabled back fullyQualifiedTypeName unittests

### DIFF
--- a/source/vibe/http/rest.d
+++ b/source/vibe/http/rest.d
@@ -769,24 +769,22 @@ unittest
     	== "vibe.data.json.Json[vibe.data.json.Json]");
 
     // these currently fail because fullyQualifiedName!T returns nonsense for inner types
-    version(none){
-	    static assert(fullyQualifiedTypeName!(QualifiedNameTests.Inner)
-			== "vibe.http.rest.QualifiedNameTests.Inner");
-	    static assert(fullyQualifiedTypeName!(ReturnType!(QualifiedNameTests.func))
-			== "const(vibe.http.rest.QualifiedNameTests.Inner[immutable(char)[]])");
-	    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.func))
-			== "const(vibe.http.rest.QualifiedNameTests.Inner[immutable(char)[]])(vibe.http.rest.QualifiedNameTests.Inner, immutable(char)[])");
-	    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.data))
-			== "shared(const(vibe.http.rest.QualifiedNameTests.Inner[immutable(char)[]])[])");
-	    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.deleg))
-			== "vibe.http.rest.QualifiedNameTests.Inner(double, immutable(char)[])");
-	    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.array))
-	    	== "vibe.http.rest.QualifiedNameTests.Inner[]");
-	    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.sarray))
-	    	== "vibe.http.rest.QualifiedNameTests.Inner[16]");
-	    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.aarray))
-	    	== "vibe.http.rest.QualifiedNameTests.Inner[vibe.http.rest.QualifiedNameTests.Inner]");
-	}
+    static assert(fullyQualifiedTypeName!(QualifiedNameTests.Inner)
+        == "vibe.http.rest.QualifiedNameTests.Inner");
+    static assert(fullyQualifiedTypeName!(ReturnType!(QualifiedNameTests.func))
+        == "const(vibe.http.rest.QualifiedNameTests.Inner[immutable(char)[]])");
+    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.func))
+        == "const(vibe.http.rest.QualifiedNameTests.Inner[immutable(char)[]])(vibe.http.rest.QualifiedNameTests.Inner, immutable(char)[])");
+    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.data))
+        == "shared(const(vibe.http.rest.QualifiedNameTests.Inner[immutable(char)[]])[])");
+    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.deleg))
+        == "vibe.http.rest.QualifiedNameTests.Inner(double, immutable(char)[])");
+    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.array))
+        == "vibe.http.rest.QualifiedNameTests.Inner[]");
+    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.sarray))
+        == "vibe.http.rest.QualifiedNameTests.Inner[16]");
+    static assert(fullyQualifiedTypeName!(typeof(QualifiedNameTests.aarray))
+        == "vibe.http.rest.QualifiedNameTests.Inner[vibe.http.rest.QualifiedNameTests.Inner]");
 }
 
 /// private


### PR DESCRIPTION
My small fix to fullyQualifiedName is in Phobos in 2.061, so I have enabled those again.
And hope with next release proper Phobos implementation of fullyQualifiedTypeName itself will be available :)
