### PR TITLE
[trivial] Typo in writeBody documentation

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -565,7 +565,7 @@ final class HttpServerResponse : HttpResponse {
 	*/
 	bool isHeadResponse() const { return m_isHeadResponse; }
 
-	/// Writes the hole response body at once.
+	/// Writes the entire response body at once.
 	void writeBody(in ubyte[] data, string content_type = null)
 	{
 		if( content_type ) headers["Content-Type"] = content_type;


### PR DESCRIPTION
Probably meant "whole". I think "entire" reads better.
