### PR TITLE
Fix for #163 : Improved import detection for REST interface generators

### DIFF
--- a/source/vibe/http/rest.d
+++ b/source/vibe/http/rest.d
@@ -771,22 +771,22 @@ template getSymbols(T)
 
     static if (isAggregateType!T || is(T == enum))
     {   
-        alias getSymbols = TypeTuple!T;
+        alias TypeTuple!T getSymbols;
     }  
     else static if (isStaticArray!T || isArray!T)
     {
-        alias getSymbols = getSymbols!(typeof(T.init[0]));
+        alias getSymbols!(typeof(T.init[0])) getSymbols;
     }
     else static if (isAssociativeArray!T)
     {   
-        alias getSymbols = TypeTuple!( getSymbols!(ValueType!T) , getSymbols!(KeyType!T) );
+        alias TypeTuple!( getSymbols!(ValueType!T) , getSymbols!(KeyType!T) ) getSymbols;
     }   
     else static if (isPointer!T)
     {
-    	alias getSymbols = getSymbols!(PointerTarget!T);
+    	alias getSymbols!(PointerTarget!T) getSymbols;
     }
     else
-        alias getSymbols = TypeTuple!();
+        alias TypeTuple!() getSymbols;
 }
 
 unittest


### PR DESCRIPTION
Follow-up for https://github.com/rejectedsoftware/vibe.d/issues/163
I have no idea how to forge external modules for unit-testing generateModuleImports so tested only on my code. Please review carefully.

I wonder if some more generic type/symbol processing primitives can be designed (and included in phobos) instead of stockpiling similar utility functions.
