### PR TITLE
Add convenience method to Json struct to output pretty strings

### DIFF
--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -659,9 +659,7 @@ struct Json {
 		// }
 	*/
 	string toPrettyString(int level = 0) const {
-		auto ret = appender!string();
-		toPrettyJson(ret, this, level);
-		return ret.data;
+		return toPrettyJson(this, level);
 	}
 
 	private void checkType(T)()


### PR DESCRIPTION
added convenience method to Json struct to output pretty strings and also added level (default == 0) parameter to "toPrettyJson()" overload
