### PR TITLE
Added range for MongoCursor

### DIFF
--- a/tests/source/tests/mongodb.d
+++ b/tests/source/tests/mongodb.d
@@ -16,13 +16,23 @@ void test_mongodb_general()
 	coll.insert([ "key1" : "value1", "key2" : "value2"]);
 	coll.update(["key1" : "value1"], [ "key1" : "value1", "key2" : "1337"]);
 	assert(coll.database.getLastError().n == 1);
-	auto data = coll.find(["key1" : true]);
-	foreach (doc; data)
-	{
-	    assert(doc.length == 1);
-	    assert(doc.key2.get!string() == "1337");
-	}
+	auto data = coll.findOne(["key1" : "value1"]);
+    assert(!data.isNull());
+    assert(data.key2.get!string() == "1337");
 	coll.database.fsync();
 	auto logBson = client.getDatabase("admin").getLog("global");
 	assert(!logBson.isNull());
+
+    // testing cursor range interface
+	coll.remove();
+	coll.insert(["key1" : "value1"]);
+    coll.insert(["key1" : "value2"]);
+    coll.insert(["key1" : "value2"]);
+    auto data1 = coll.find(["key1" : "value1"]);
+    auto data2 = coll.find(["key1" : "value2"]);
+
+    import std.range;
+    auto converted = zip(data1.range, data2.range).map!( a => a[0].key1.get!string() ~ a[1].key1.get!string() )();
+    assert(!converted.empty);
+    assert(converted.front == "value1value2");
 }


### PR DESCRIPTION
One of enhancement I have long wanted - working with MongoCursor with InputRange interface. Allows for more functional way to process database data into final output with all std.algorithm & friends help.

Motivating example from tests:

```
coll.insert(["key1" : "value1"]);
coll.insert(["key1" : "value2"]);
coll.insert(["key1" : "value2"]);
auto data1 = coll.find(["key1" : "value1"]);
auto data2 = coll.find(["key1" : "value2"]);

import std.range, std.algorithm;
auto converted = map!
    (a => a[0].key1.get!string() ~ a[1].key1.get!string())(
        zip(data1.range, data2.range)
    );
assert(!converted.empty);
assert(converted.front == "value1value2");
```
