### PR TITLE
Add @property setters for Cookie properties.

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -397,24 +397,31 @@ final class Cookie {
 	}
 
 	Cookie setValue(string value) { m_value = value; return this; }
+	@property void value(string value) { m_value = value; }
 	@property string value() { return m_value; }
 
 	Cookie setDomain(string domain) { m_domain = domain; return this; }
+	@property void domain(string value) { m_domain = value; }
 	@property string domain() { return m_domain; }
 
 	Cookie setPath(string path) { m_path = path; return this; }
+	@property void path(string value) { m_path = value; }
 	@property string path() { return m_path; }
 
 	Cookie setExpire(string expires) { m_expires = expires; return this; }
+	@property void expires(string value) { m_expires = value; }
 	@property string expires() { return m_expires; }
 
 	Cookie setMaxAge(long maxAge) { m_maxAge = maxAge; return this;}
+	@property void maxAge(long value) { m_maxAge = value; }
 	@property long maxAge() { return m_maxAge; }
 
 	Cookie setSecure(bool enabled) { m_secure = enabled; return this; }
+	@property void isSecure(bool value) { m_secure = value; }
 	@property bool isSecure() { return m_secure; }
 
 	Cookie setHttpOnly(bool enabled) { m_httpOnly = enabled; return this; }
+	@property void isHttpOnly(bool value) { m_httpOnly = value; }
 	@property bool isHttpOnly() { return m_httpOnly; }
 
 }


### PR DESCRIPTION
It's kinda weird to have idiomatic D @property getters for members of class Cookie like isSecure, path, maxAge, etc, but then for _setting_ them only offer Java-like setSecure, setPath, setMaxAge, etc.

I realize the set*() funcs are to allow chaining, and that's fine, but I'm not sure that should preclude inclusion of idiomatic setters.
