### PR TITLE
Allow names with only one char in adjustMethodStyle..

### DIFF
--- a/source/vibe/http/rest.d
+++ b/source/vibe/http/rest.d
@@ -342,7 +342,7 @@ string adjustMethodStyle(string name, MethodStyle style)
 		case MethodStyle.upperUnderscored:
 			string ret;
 			size_t start = 0, i = 1;
-			while( i < name.length ){
+			while( i <= name.length ){
 				while( i < name.length && !(name[i] >= 'A' && name[i] <= 'Z') ) i++;
 				if( ret.length > 0 ) ret ~= "_";
 				ret ~= name[start .. i];


### PR DESCRIPTION
Just a small fix to adjustMethodStyle.

Testcase:

```
interface ITest { Json getQ(Json q); }
class Test : ITest { Json getQ(Json q) { return q; } }
// REST route: POST / ["q"]
```
