### PR TITLE
Content-Type should specify charset for JSON responses

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -655,7 +655,7 @@ final class HttpServerResponse : HttpResponse {
 		}
 
 		statusCode = status;
-		writeBody(cast(ubyte[])serializeToJson(data).toString(), "application/json");
+		writeBody(cast(ubyte[])serializeToJson(data).toString(), "application/json; charset=utf-8");
 	}
 
 	/**


### PR DESCRIPTION
UTF-8 is indeed the default, but this prevents encoding issues in Webkit browsers. 

"JSON text SHALL be encoded in Unicode. The default encoding is UTF-8."
http://www.ietf.org/rfc/rfc4627.txt
