### PR TITLE
Redis connection pooling

### DIFF
--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -112,7 +112,7 @@ private final class RedisConnection : EventedObject {
 	}
 
 	T request(T=RedisReply)(string command, in ubyte[][] args...) {
-		if( !m_conn /*|| !m_conn.connected*/ ){
+		if( !m_conn || !m_conn.connected ){
 			m_conn = connectTcp(m_host, m_port);
 		}
 		m_conn.write(format("*%d\r\n$%d\r\n%s\r\n", args.length + 1, command.length, command));


### PR DESCRIPTION
I added connection pooling to the Redis client. Previously the client could only be used from a single fiber, with no way of moving it to another. That's now handled automatically by the connection pool.
