### PR TITLE
Win compilation fail. Forward reference of nullSlotDummy and slotCompare.

### DIFF
--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -325,6 +325,12 @@ logDebug("dnsresolve ret %s", dnsinfo.status);
 }
 
 class Libevent2ManualEvent : ManualEvent {
+	
+	/// private
+	static Thread nullSlotDummy() { return null; }
+	/// private
+	static bool slotCompare(in Thread a, in Thread b) { return a is b; }
+	
 	private {
 		struct ThreadSlot {
 			Libevent2Driver driver;
@@ -336,11 +342,6 @@ class Libevent2ManualEvent : ManualEvent {
 		alias ThreadSlotMap = HashMap!(Thread, ThreadSlot, nullSlotDummy, slotCompare);
 		ThreadSlotMap m_waiters;
 	}
-
-	/// private
-	static Thread nullSlotDummy() { return null; }
-	/// private
-	static bool slotCompare(in Thread a, in Thread b) { return a is b; }
 
 	this()
 	{


### PR DESCRIPTION
Platform: Windows 7 x86_64
DMD: 2.062
Log:

```
Checking dependencies in 'D:\dev\d\foguansite'
Building configuration "application", build type debug
Copying files...
Running dmd (compile)...
.dub\packages\vibe-d\source\vibe\core\drivers\libevent2.d(336): Error: template instance vibe.utils.hashmap.HashMap!(Thread, ThreadSlot, nullSlotDummy, slotCompare) forward reference of function nullSlotDummy
.dub\packages\vibe-d\source\vibe\core\drivers\libevent2.d(336): Error: template instance vibe.utils.hashmap.HashMap!(Thread, ThreadSlot, nullSlotDummy, slotCompare) forward reference of function slotCompare
.dub\packages\vibe-d\source\vibe\core\drivers\libevent2.d(336): Error: template instance vibe.utils.hashmap.HashMap!(Thread, ThreadSlot, nullSlotDummy, slotCompare) error instantiating
C:\D\dmd2\windows\bin\..\..\src\phobos\std\range.d(611): Error: static assert  "Cannot put a char[] into a Appender!(string)"
C:\D\dmd2\windows\bin\..\..\src\phobos\std\format.d(1436):        instantiated from here: put!(Appender!(string), char[])
C:\D\dmd2\windows\bin\..\..\src\phobos\std\format.d(1338):        instantiated from here: formatUnsigned!(Appender!(string), char)
C:\D\dmd2\windows\bin\..\..\src\phobos\std\format.d(1312):        instantiated from here: formatIntegral!(Appender!(string), ulong, char)
C:\D\dmd2\windows\bin\..\..\src\phobos\std\format.d(1071):        ... (12 instantiations, -v to show) ...
C:\D\dmd2\windows\bin\..\..\src\phobos\std\uuid.d(371):        instantiated from here: parse!(ubyte, string)
C:\D\dmd2\windows\bin\..\..\src\phobos\std\uuid.d(1468):        instantiated from here: __ctor!(immutable(char))
Error: Build command failed with exit code 1

Run 'dub help' for usage information.
```

Easy fix to move nullSlotDummy and slotCompare  above the alias.
