### PR TITLE
Enable BSON and JSON serialization/deserialization of enum strings

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -325,7 +325,7 @@ struct Bson {
 				auto tp = cast(Type)d[0];
 				if( tp == Type.End ) break;
 				d = d[1 .. $];
-				auto key = skipCString(d);	
+				auto key = skipCString(d);
 				auto value = Bson(tp, d);
 				d = d[value.data.length .. $];
 
@@ -893,7 +893,7 @@ Bson serializeToBson(T)(T value)
 	else static if( is(Unqualified == double) ) return Bson(value);
 	else static if( is(Unqualified : int) ) return Bson(cast(int)value);
 	else static if( is(Unqualified : long) ) return Bson(cast(long)value);
-	else static if( is(Unqualified == string) ) return Bson(value);
+	else static if( is(Unqualified : string) ) return Bson(value);
 	else static if( is(Unqualified : const(ubyte)[]) ) return Bson(BsonBinData(BsonBinData.Type.Generic, value.idup));
 	else static if( isArray!T ){
 		auto ret = new Bson[value.length];
@@ -963,7 +963,7 @@ T deserializeBson(T)(Bson src)
 	else static if( is(T == double) ) return cast(double)src;
 	else static if( is(T : int) ) return cast(T)cast(int)src;
 	else static if( is(T : long) ) return cast(T)cast(long)src;
-	else static if( is(T == string) ) return cast(string)src;
+	else static if( is(T : string) ) return cast(T)(cast(string)src);
 	else static if( is(T : const(ubyte)[]) ) return cast(T)src.get!BsonBinData.rawData.dup;
 	else static if( isArray!T ){
 		alias typeof(T.init[0]) TV;
@@ -1017,8 +1017,10 @@ T deserializeBson(T)(Bson src)
 
 unittest {
 	import std.stdio;
-	static struct S { float a; double b; bool c; int d; string e; byte f; ubyte g; long h; ulong i; float[] j; }
-	immutable S t = {1.5, -3.0, true, int.min, "Test", -128, 255, long.min, ulong.max, [1.1, 1.2, 1.3]};
+	enum Foo : string { k = "test" }
+	enum Boo : int { l = 5 }
+	static struct S { float a; double b; bool c; int d; string e; byte f; ubyte g; long h; ulong i; float[] j; Foo k; Boo l;}
+	immutable S t = {1.5, -3.0, true, int.min, "Test", -128, 255, long.min, ulong.max, [1.1, 1.2, 1.3], Foo.k, Boo.l,};
 	S u;
 	deserializeBson(u, serializeToBson(t));
 	assert(t.a == u.a);
@@ -1031,6 +1033,8 @@ unittest {
 	assert(t.h == u.h);
 	assert(t.i == u.i);
 	assert(t.j == u.j);
+	assert(t.k == u.k);
+	assert(t.l == u.l);
 }
 
 unittest {

--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -179,7 +179,7 @@ struct Json {
 		Allows removement of values from Type.Object Json objects.
 	*/
 	void remove(string item) { checkType!(Json[string])(); m_object.remove(item); }
-	
+
 	/**
 		The current type id of this JSON object.
 	*/
@@ -884,7 +884,7 @@ Json serializeToJson(T)(T value)
 	else static if( is(TU == DateTime) ) return Json(value.toISOExtString());
 	else static if( is(TU == SysTime) ) return Json(value.toISOExtString());
 	else static if( is(TU : long) ) return Json(cast(long)value);
-	else static if( is(TU == string) ) return Json(value);
+	else static if( is(TU : string) ) return Json(value);
 	else static if( isArray!T ){
 		auto ret = new Json[value.length];
 		foreach( i; 0 .. value.length )
@@ -947,7 +947,7 @@ T deserializeJson(T)(Json src)
 	else static if( is(T == DateTime) ) return DateTime.fromISOExtString(src.get!string);
 	else static if( is(T == SysTime) ) return SysTime.fromISOExtString(src.get!string);
 	else static if( is(T : long) ) return cast(T)src.get!long;
-	else static if( is(T == string) ) return src.get!string;
+	else static if( is(T : string) ) return cast(T)src.get!string;
 	else static if( isArray!T ){
 		alias typeof(T.init[0]) TV;
 		auto dst = new Unqual!TV[src.length];
@@ -996,8 +996,10 @@ T deserializeJson(T)(Json src)
 
 unittest {
 	import std.stdio;
-	static struct S { float a; double b; bool c; int d; string e; byte f; ubyte g; long h; ulong i; float[] j; }
-	immutable S t = {1.5, -3.0, true, int.min, "Test", -128, 255, long.min, ulong.max, [1.1, 1.2, 1.3]};
+	enum Foo : string { k = "test" }
+	enum Boo : int { l = 5 }
+	static struct S { float a; double b; bool c; int d; string e; byte f; ubyte g; long h; ulong i; float[] j; Foo k; Boo l; }
+	immutable S t = {1.5, -3.0, true, int.min, "Test", -128, 255, long.min, ulong.max, [1.1, 1.2, 1.3], Foo.k, Boo.l};
 	S u;
 	deserializeJson(u, serializeToJson(t));
 	assert(t.a == u.a);
@@ -1010,6 +1012,8 @@ unittest {
 	assert(t.h == u.h);
 	assert(t.i == u.i);
 	assert(t.j == u.j);
+	assert(t.k == u.k);
+	assert(t.l == u.l);
 }
 
 unittest {


### PR DESCRIPTION
This pull enables the BSON and JSON serialization/deserialization for enum strings. My tests ran successfully but please double check.
