### PR TITLE
"Unprivate" constructor of http.session.Session

### DIFF
--- a/source/vibe/http/session.d
+++ b/source/vibe/http/session.d
@@ -25,7 +25,7 @@ final class Session {
 		string m_id;
 	}
 
-	private this(SessionStore store, string id = null)
+	this(SessionStore store, string id = null)
 	{
 		m_store = store;
 		if (id) {


### PR DESCRIPTION
The constructor should be public, since the class is a part of the SessionStore interface.
