### PR TITLE
Allow for RFC 2616 chunk extensions

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -365,8 +365,8 @@ final class ChunkedInputStream : InputStream {
 	{
 		// read chunk header
 		logTrace("read next chunk header");
-		auto ln = m_in.readLine();
-		ulong sz = toImpl!ulong(cast(string)ln, 16u);
+		auto ln = cast(string)m_in.readLine();
+		ulong sz = parse!ulong(ln, 16u);
 		m_bytesInCurrentChunk = sz;
 
 		if( m_bytesInCurrentChunk == 0 ){


### PR DESCRIPTION
According to [RFC 2616](http://tools.ietf.org/html/rfc2616#section-3.6.1), chunks can have extensions. This patch just parses the chunk size and ignores the rest of the line. It also allows for websites I have encountered which have extra whitespace between the size and CRLF.
