### PR TITLE
fix serialize to Json/Bson for const struct classes

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -907,11 +907,11 @@ Bson serializeToBson(T)(T value)
 		foreach( string key, value; value )
 			ret[key] = serializeToBson(value);
 		return Bson(ret);
-	} else static if( __traits(compiles, value = T.fromBson(value.toBson())) ){
+	} else static if( is(typeof(value.toBson()) == Bson) ){
 		return value.toBson();
-	} else static if( __traits(compiles, value = T.fromJson(value.toJson())) ){
+	} else static if( is(typeof(value.toJson()) == Json) ){
 		return Bson.fromJson(value.toJson());
-	} else static if( __traits(compiles, value = T.fromString(value.toString())) ){
+	} else static if( is(typeof(value.toString()) == string) ){
 		return Bson(value.toString());
 	} else static if( is(Unqualified == struct) ){
 		Bson[string] ret;

--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -900,9 +900,9 @@ Json serializeToJson(T)(T value)
 		foreach( string key, value; value )
 			ret[key] = serializeToJson(value);
 		return Json(ret);
-	} else static if( __traits(compiles, value = T.fromJson(value.toJson())) ){
+	} else static if( is(typeof(value.toJson()) == Json) ){
 		return value.toJson();
-	} else static if( __traits(compiles, value = T.fromString(value.toString())) ){
+	} else static if( is(typeof(value.toString()) == string) ){
 		return Json(value.toString());
 	} else static if( is(TU == struct) ){
 		Json[string] ret;


### PR DESCRIPTION
Function serializeToJson/Bson ignores custom toJson/Bson members for constant structs/classes.

``` d
struct A {
    int value;
    static A fromJson(Json val) { return A(val.get!int); }
    Json toJson() const { return Json(value); }
}
shared static this() {
    assert(serializeToJson(A(123)) == Json(123));       // okay, works as expected
    assert(serializeToJson(const A(123)) == Json(123)); // fails, serializes as object {"value": 123} instead simple integer.
}
```

Also I believe that functions toJson/Bson/String should returns Json, Bson and string values accordingly, but not values just implicitly convertible to those types.

Tests for this pull request:

``` d
import vibe.d;

// struct with Json conversions
struct A {
    int value;

    static A fromJson(Json val) { return A(val.get!int); }
    Json toJson() const { return Json(value); }
}

// struct with Bson conversions
struct B {
    int value;

    static B fromBson(Bson val) { return B(val.get!int); }
    Bson toBson() const { return Bson(value); }
}

// struct with string conversions
struct C {
    int value;

    static C fromString(string val) { return C(val.to!int); }
    string toString() const { return value.to!string; }
}

// struct without any conversions
struct D {
    int value;
}

shared static this() {
    assert(serializeToJson(const A(123)) == Json(123));
    assert(serializeToJson(A(123))       == Json(123));
    assert(serializeToBson(const A(123)) == Bson(123));
    assert(serializeToBson(A(123))       == Bson(123));

    assert(serializeToJson(const B(123)) == serializeToJson(["value": 123]));
    assert(serializeToJson(B(123))       == serializeToJson(["value": 123]));
    assert(serializeToBson(const B(123)) == Bson(123));
    assert(serializeToBson(B(123)) == Bson(123));

    assert(serializeToJson(const C(123)) == Json("123"));
    assert(serializeToJson(C(123))       == Json("123"));
    assert(serializeToBson(const C(123)) == Bson("123"));
    assert(serializeToBson(C(123))       == Bson("123"));

    assert(serializeToJson(const D(123)) == serializeToJson(["value": 123]));
    assert(serializeToJson(D(123))       == serializeToJson(["value": 123]));
    assert(serializeToBson(const D(123)) == serializeToBson(["value": 123]));
    assert(serializeToBson(D(123))       == serializeToBson(["value": 123]));
}
```
