### PR TITLE
Documentation correction for MongoCursor empty() property.

### DIFF
--- a/source/vibe/db/mongo/cursor.d
+++ b/source/vibe/db/mongo/cursor.d
@@ -43,7 +43,7 @@ struct MongoCursor {
 	}
 
 	/**
-		Returns true if there are more documents for this cursor.
+		Returns true if there are no more documents for this cursor.
 
 		Throws: An exception if there is a query or communication error.
 	*/


### PR DESCRIPTION
The documentation states the empty() returns true when there are more documents for the cursor, but based on the name (and my tests) it returns true when there are 'no more' documents for the cursor.
