### PR TITLE
Change EmptyObject to emptyObject in Example

### DIFF
--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -10,7 +10,7 @@
 	void manipulateJson(Json j)
 	{
 		// object members can be accessed using member syntax, just like in JavaScript
-		j = Json.EmptyObject;
+		j = Json.emptyObject;
 		j.name = "Example";
 		j.id = 1;
 


### PR DESCRIPTION
According to compiler, EmptyObject was deprecated in favour of emptyObject.
