### PR TITLE
regression requests on keep-alive HTTP connections only served after 40ms

### DIFF
--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -78,7 +78,7 @@ package class Libevent2TCPConnection : TCPConnection {
 		evutil_inet_ntop(ctx.remote_addr.family, ptr, m_peerAddressBuf.ptr, m_peerAddressBuf.length);
 		m_peerAddress = cast(string)m_peerAddressBuf[0 .. m_peerAddressBuf.indexOf('\0')];
 
-		bufferevent_setwatermark(m_ctx.event, EV_WRITE, 0, 65536);
+		bufferevent_setwatermark(m_ctx.event, EV_WRITE, 4096, 65536);
 	}
 	
 	~this()
@@ -272,7 +272,7 @@ package class Libevent2TCPConnection : TCPConnection {
 		auto outbuf = bufferevent_get_output(m_ctx.event);
 		if( bufferevent_write(m_ctx.event, cast(char*)bytes.ptr, bytes.length) != 0 )
 			throw new Exception("Failed to write data to buffer");
-		while (connected && evbuffer_get_length(outbuf) > 0) rawYield();
+		while (connected && evbuffer_get_length(outbuf) > 4096) rawYield();
 	}
 
 	void write(InputStream stream, ulong nbytes = 0)


### PR DESCRIPTION
The method `Libevent2TCPConnection.waitForData` only returns after 40ms.
In v0.7.17 I see `socket 11 write event (false)!` after `wait for data`. The write event  is missing on master.
I tried to bisect the issue but there were to many build errors in the git history to do so.
