### PR TITLE
fix excessive compile times, unneeded initialization

### DIFF
--- a/source/vibe/core/stream.d
+++ b/source/vibe/core/stream.d
@@ -105,7 +105,7 @@ interface OutputStream {
 
 	protected final void writeDefault(InputStream stream, ulong nbytes = 0)
 	{
-		static struct Buffer { ubyte[64*1024] bytes; }
+		static struct Buffer { ubyte[64*1024] bytes = void; }
 		auto bufferobj = FreeListRef!(Buffer, false)();
 		auto buffer = bufferobj.bytes[];
 

--- a/source/vibe/stream/operations.d
+++ b/source/vibe/stream/operations.d
@@ -273,4 +273,4 @@ string readAllUTF8(InputStream stream, bool sanitize = false, size_t max_bytes =
 /// Deprecated compatibility alias
 deprecated("Please use readAllUTF8 instead.") alias readAllUtf8 = readAllUTF8;
 
-private struct Buffer { ubyte[64*1024] bytes; }
+private struct Buffer { ubyte[64*1024] bytes = void; }


### PR DESCRIPTION
- Array initializer trigger O(N^2) behavior in dmd.
- Buffers don't need initialization.
