### PR TITLE
Fix @property regressions introduces by UDA module update

### DIFF
--- a/examples/rest/source/app.d
+++ b/examples/rest/source/app.d
@@ -267,15 +267,15 @@ unittest
  * There is also another attribute function type that can be called
  * to post-process method return value.
  *
- * Refer to `vibe.utils.meta.funcattr` for more details.
+ * Refer to `vibe.internal.meta.funcattr` for more details.
  */
 @rootPathFromName
 interface Example5API
 {
-	import vibe.utils.meta.funcattr;
+	import vibe.http.rest : before, after;
 
 	@before!authenticate("user") @after!addBrackets()
-	string getSecret(int num, User user);	
+	string getSecret(int num, User user);
 }
 
 User authenticate(HTTPServerRequest req, HTTPServerResponse res)

--- a/source/vibe/internal/meta/traits.d
+++ b/source/vibe/internal/meta/traits.d
@@ -14,12 +14,18 @@ module vibe.internal.meta.traits;
 
 	Returns: `true` if argument is a getter
  */
-template isPropertyGetter(T)
+template isPropertyGetter(T...)
+	if (T.length == 1)
 {
-	import std.traits : functionAttributes, FunctionAttribute, ReturnType;
-	
-	enum isPropertyGetter = (functionAttributes!(T) & FunctionAttribute.property) != 0
-		&& !is(ReturnType!T == void);
+	import std.traits : functionAttributes, FunctionAttribute, ReturnType,
+		isSomeFunction;
+	static if (isSomeFunction!(T[0])) {
+		enum isPropertyGetter = 
+			(functionAttributes!(T[0]) & FunctionAttribute.property) != 0
+			&& !is(ReturnType!T == void);
+	}
+	else
+		enum isPropertyGetter = false;
 }
 
 ///
@@ -35,6 +41,7 @@ unittest
 	static assert(isPropertyGetter!(typeof(&Test.getter)));
 	static assert(!isPropertyGetter!(typeof(&Test.setter)));
 	static assert(!isPropertyGetter!(typeof(&Test.simple)));
+	static assert(!isPropertyGetter!int);
 }
 
 /**
@@ -42,12 +49,19 @@ unittest
 
 	Returns: `true` if argument is a setter
  */
-template isPropertySetter(T)
+template isPropertySetter(T...)
+	if (T.length == 1)
 {
-	import std.traits : functionAttributes, FunctionAttribute, ReturnType;
+	import std.traits : functionAttributes, FunctionAttribute, ReturnType,
+		isSomeFunction;
 
-	enum isPropertySetter = (functionAttributes!(T) & FunctionAttribute.property) != 0
-		&& is(ReturnType!T == void);
+	static if (isSomeFunction!(T[0])) {
+		enum isPropertySetter = 
+			(functionAttributes!(T) & FunctionAttribute.property) != 0
+			&& is(ReturnType!(T[0]) == void);
+	}
+	else
+		enum isPropertySetter = false;
 }
 
 ///
@@ -63,6 +77,7 @@ unittest
 	static assert(isPropertySetter!(typeof(&Test.setter)));
 	static assert(!isPropertySetter!(typeof(&Test.getter)));
 	static assert(!isPropertySetter!(typeof(&Test.simple)));
+	static assert(!isPropertySetter!int);
 }
 
 /**


### PR DESCRIPTION
Recent change to `findFirstUDA` has introduced a regression in a way that symbol of property function used for attribute got captured into result instead of returned value. This fixes it and also makes `isPropertyGetter/Setter` tiny bit more versatile.

Also:
1) fixes rest test suite to stop referring removed module
2) public import of `before` and `after` from `vibe.http.rest`
