### PR TITLE
Fixed an exception raised with empty json requests.

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1365,7 +1365,9 @@ private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTT
 		if( settings.options & HTTPServerOption.parseJsonBody ){
 			if( req.contentType == "application/json" ){
 				auto bodyStr = cast(string)req.bodyReader.readAll();
-				req.json = parseJson(bodyStr);
+				if ( !bodyStr.empty ){
+					req.json = parseJson(bodyStr);	
+				}
 			}
 		}
 


### PR DESCRIPTION
Empty body requests with ‘Content-Type=application/json’ raise the exception “JSON string is empty.” when it tries to parse the result. 

This is a huge issue with GET requests that use the content type to return either a html or json response.
