### PR TITLE
Keep alive

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -543,7 +543,7 @@ final class HTTPClientResponse : HTTPResponse {
 		if (this.headers.get("Connection") == "close") {
 			// do nothing, forcing disconnect() before next request
 		} else if (m_client.m_timeout > 0 && max > 1) {
-			m_client.m_keepAliveLimit += m_client.m_timeout.seconds;
+			m_client.m_keepAliveLimit += (m_client.m_timeout - 2).seconds;
 		} else if (this.httpVersion == HTTPVersion.HTTP_1_1) {
 			m_client.m_keepAliveLimit += 60.seconds;
 		}


### PR DESCRIPTION
Fix for https://github.com/rejectedsoftware/vibe.d/issues/448
The logic is: 
1.  connection=close takes priority. 
2. If the server tells us timeout and max, we use that.
3. Otherwise we go with the HTTP 1.1 default of assuming the connection remains open. It's unclear (at least from my googling around) what the default timeout value should be, so I went with 1 minute.

Also I changed  `if (m_client.m_timeout > 0 && max > 1)` because keepAliveLimit+=timeout is already a conservative value, as the client set keepAliveLimit to a moment in time before the request was transmitted. So without subtracting 2s, the client's notion of connection timeout will be before the server's notion of it.
