### PR TITLE
Provide explicit Bson.toString() method.

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -452,6 +452,12 @@ struct Bson {
 		}
 	}
 
+	/** Returns a string representation of this BSON value in JSON format.
+	*/
+	string toString()
+	{
+		return toJson().toString();
+	}
 
 	/** Allows accessing fields of a BSON object using [].
 


### PR DESCRIPTION
Otherwise, opDispatch() will be invoked when trying to
writeln() a Bson object for debugging purposes, leading to
a confusing exception.

I'm not sure whether goign through Json is the best idea,
it just seemed like a convenient fix for the time being.
