### PR TITLE
Safe discover of redis version

### DIFF
--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -53,9 +53,12 @@ final class RedisClient {
 		auto info = info();
 		auto lines = info.splitLines();
 		if (lines.length > 1) {
-			auto lineParams = lines[1].split(":");
-			if (lineParams.length > 1 && lineParams[0] == "redis_version") {
-				m_version = lineParams[1];
+			foreach (string line; lines) {
+				auto lineParams = line.split(":");
+				if (lineParams.length > 1 && lineParams[0] == "redis_version") {
+					m_version = lineParams[1];
+					break;
+				}
 			}
 		} 
 	}


### PR DESCRIPTION
My original pull request worked well for redis version 2.6.12 on Windows 8.1 (my test system) but does not work on my production site (redis version 2.2.12 and ubuntu 12.04.4 LTS). On Windows 8.1 and Redis 2.6.12 lines[0] equals "#Server" (like the doc - http://redis.io/commands/info) but on production site lines[0] contains the version.
So I think this is the better solution for retrieving the redis version independent of OS-/Redis-Version. 
