### PR TITLE
Added blpop and adjusted to signed 64 bit numbers

### DIFF
--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -415,7 +415,7 @@ final class RedisReply {
 	private ubyte[] readBulk( string sizeLn )
 	{
 		if (sizeLn.startsWith("$-1")) return null;
-		auto size = to!long( sizeLn[1 .. $] );
+		auto size = to!size_t( sizeLn[1 .. $] );
 		auto data = new ubyte[size];
 		m_conn.read(data);
 		m_conn.readLine();


### PR DESCRIPTION
Because we're finalizing the Redis API, I thought it would be important to make some better decisions.

First, it's very unsafe for the API to use size_t b/c on i386 platforms forcing 32 bit integers could result in data loss considering Redis sends a string of a 64 bit integers always.

I added `bblpop` as a blocking list pop and a non-blocking list `blpop` as a task with concurrency. An issue I pointed out earlier was that redis was not precise on its timeout. The suggestion was to close the connection after 10 seconds, but using a task the best workaround would be to run :

`auto value = redis.blpop!(string[])(10.seconds, "list1", "list2").receiveTimeout!string(10.seconds);`
`redis.lpush("list1", "1"); // satisfies the receive loop in blpop` 

This way, the connection will be recycled and the timeout ends nearer to 10s rather than 10.66s+.

I'd also like to suggest changing the template parameters, ie. `lindex(T : E[], E)` should be `lindex(T)` b/c there would be more logic requesting the response type rather than specifying the underlying range.
