### PR TITLE
support function pointer in match method of URLRouter

### DIFF
--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -142,6 +142,12 @@ class URLRouter : HTTPRouter {
 		m_routes[method] ~= Route(path, cb);
 		return this;
 	}
+
+	/// ditto
+	URLRouter match(HTTPMethod method, string path, HTTPServerRequestFunction cb)
+	{
+		return match(method,path,toDelegate(cb));
+	}
 	
 	/// Handles a HTTP request by dispatching it to the registered route handlers.
 	void handleRequest(HTTPServerRequest req, HTTPServerResponse res)


### PR DESCRIPTION
this is to support the following code:

```
import vibe.d;

void index(HTTPServerRequest req, HTTPServerResponse res){}

shared static this()
{
    auto router = new URLRouter;
    router.match(HTTPMethod.OPTIONS,"*", &index);

    listenHTTP(new HTTPServerSettings, router);
}
```

without this change the compiler refuses with:

```
source\app.d(8): Error: function vibe.http.router.URLRouter.match (HTTPMethod method, string path, v
oid delegate(HTTPServerRequest req, HTTPServerResponse res) cb) is not callable using argument types
 (HTTPMethod, string, void function(HTTPServerRequest req, HTTPServerResponse res))
```

is this maybe even a compiler bug ??
