### PR TITLE
Remove final from HTTPServerResponse and Request

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -55,14 +55,14 @@ import std.uri;
 	request_handler will be called for each HTTP request that is made. The
 	res parameter of the callback then has to be filled with the response
 	data.
-	
+
 	request_handler can be either HTTPServerRequestDelegate/HTTPServerRequestFunction
 	or a class/struct with a member function 'handleRequest' that has the same
 	signature.
 
 	Note that if the application has been started with the --disthost command line
 	switch, listenHTTP() will automatically listen on the specified VibeDist host
-	instead of locally. This allows for a seamless switch from single-host to 
+	instead of locally. This allows for a seamless switch from single-host to
 	multi-host scenarios without changing the code. If you need to listen locally,
 	use listenHTTPPlain() instead.
 
@@ -345,7 +345,7 @@ class HTTPServerSettings {
 	ushort port = 80;
 
 	/** The interfaces on which the HTTP server is listening.
-		
+
 		By default, the server will listen on all IPv4 and IPv6 interfaces.
 	*/
 	string[] bindAddresses = ["::", "0.0.0.0"];
@@ -356,9 +356,9 @@ class HTTPServerSettings {
 		gets a request.
 	*/
 	string hostName;
-	
+
 	/** Configures optional features of the HTTP server
-	
+
 		Disabling unneeded features can improve performance or reduce the server
 		load in case of invalid or unwanted requests (DoS).
 	*/
@@ -369,7 +369,7 @@ class HTTPServerSettings {
 		HTTPServerOption.parseJsonBody |
 		HTTPServerOption.parseMultiPartBody |
 		HTTPServerOption.parseCookies;
-	
+
 	/** Time of a request after which the connection is closed with an error; not supported yet
 
 		The default limit of 0 means that the request time is not limited.
@@ -381,14 +381,14 @@ class HTTPServerSettings {
 		The default value is 10 seconds.
 	*/
 	Duration keepAliveTimeout;// = dur!"seconds"(10);
-	
+
 	/// Maximum number of transferred bytes per request after which the connection is closed with
 	/// an error; not supported yet
 	ulong maxRequestSize = 2097152;
 
 
-	///	Maximum number of transferred bytes for the request header. This includes the request line 
-	/// the url and all headers. 
+	///	Maximum number of transferred bytes for the request header. This includes the request line
+	/// the url and all headers.
 	ulong maxRequestHeaderSize = 8192;
 
 	/// Sets a custom handler for displaying error pages for HTTP errors
@@ -500,7 +500,7 @@ enum SessionOption {
 /**
 	Represents a HTTP request as received by the server side.
 */
-final class HTTPServerRequest : HTTPRequest {
+class HTTPServerRequest : HTTPRequest {
 	private {
 		SysTime m_timeCreated;
 		FixedAppender!(string, 31) m_dateAppender;
@@ -550,7 +550,7 @@ final class HTTPServerRequest : HTTPRequest {
 			Remarks: This field is only set if HTTPServerOption.parseCookies is set.
 		*/
 		CookieValueMap cookies;
-		
+
 		/** Contains all _form fields supplied using the _query string.
 
 			Remarks: This field is only set if HTTPServerOption.parseQueryString is set.
@@ -686,7 +686,7 @@ deprecated("Please use HTTPServerRequest instead.") alias HttpServerRequest = HT
 /**
 	Represents a HTTP response as sent from the server side.
 */
-final class HTTPServerResponse : HTTPResponse {
+class HTTPServerResponse : HTTPResponse {
 	private {
 		Stream m_conn;
 		ConnectionStream m_rawConnection;
@@ -712,7 +712,7 @@ final class HTTPServerResponse : HTTPResponse {
 		m_settings = settings;
 		m_requestAlloc = req_alloc;
 	}
-	
+
 	@property SysTime timeFinalized() { return m_timeFinalized; }
 
 	/** Determines if the HTTP header has already been written.
@@ -739,7 +739,7 @@ final class HTTPServerResponse : HTTPResponse {
 	{
 		writeBody(cast(ubyte[])data, content_type);
 	}
-	
+
 	/** Writes the whole response body at once, without doing any further encoding.
 
 		The caller has to make sure that the appropriate headers are set correctly
@@ -788,7 +788,7 @@ final class HTTPServerResponse : HTTPResponse {
 
 	/**
 	 * Writes the response with no body.
-	 * 
+	 *
 	 * This method should be used in situations where no body is
 	 * requested, such as a HEAD request. For an empty body, just use writeBody,
 	 * as this method causes problems with some keep-alive connections.
@@ -804,15 +804,15 @@ final class HTTPServerResponse : HTTPResponse {
 	}
 
 	/** A stream for writing the body of the HTTP response.
-		
+
 		Note that after 'bodyWriter' has been accessed for the first time, it
 		is not allowed to change any header or the status code of the response.
 	*/
 	@property OutputStream bodyWriter()
 	{
 		assert(m_conn !is null);
-		if (m_bodyWriter) return m_bodyWriter;		
-		
+		if (m_bodyWriter) return m_bodyWriter;
+
 		assert(!m_headerWritten, "A void body was already written!");
 
 		if (m_isHeadResponse) {
@@ -845,7 +845,7 @@ final class HTTPServerResponse : HTTPResponse {
 		if (auto pce = "Content-Encoding" in headers) {
 			if (*pce == "gzip") {
 				m_gzipOutputStream = FreeListRef!GzipOutputStream(m_bodyWriter);
-				m_bodyWriter = m_gzipOutputStream; 
+				m_bodyWriter = m_gzipOutputStream;
 			} else if (*pce == "deflate") {
 				m_deflateOutputStream = FreeListRef!DeflateOutputStream(m_bodyWriter);
 				m_bodyWriter = m_deflateOutputStream;
@@ -853,9 +853,9 @@ final class HTTPServerResponse : HTTPResponse {
 				logWarn("Unsupported Content-Encoding set in response: '"~*pce~"'");
 			}
 		}
-		
+
 		return m_bodyWriter;
-	}	
+	}
 
 	/// Sends a redirect request to the client.
 	void redirect(string url, int status = HTTPStatus.Found)
@@ -903,7 +903,7 @@ final class HTTPServerResponse : HTTPResponse {
 
 	/**
 		Initiates a new session.
-		
+
 		The session is stored in the SessionStore that was specified when
 		creating the server. Depending on this, the session can be persistent
 		or temporary and specific to this server instance.
@@ -953,7 +953,7 @@ final class HTTPServerResponse : HTTPResponse {
 	}
 
 	@property ulong bytesWritten() { return m_countingWriter.bytesWritten; }
-	
+
 	/**
 		Compatibility version of render() that takes a list of explicit names and types instead
 		of variable aliases.
@@ -987,7 +987,7 @@ final class HTTPServerResponse : HTTPResponse {
 	}
 
 	// Finalizes the response. This is called automatically by the server.
-	private void finalize() 
+	private void finalize()
 	{
 		if (m_gzipOutputStream) m_gzipOutputStream.finalize();
 		if (m_deflateOutputStream) m_deflateOutputStream.finalize();
@@ -1021,8 +1021,8 @@ final class HTTPServerResponse : HTTPResponse {
 		logTrace("---------------------");
 
 		// write the status line
-		writeLine("%s %d %s", 
-			getHTTPVersionString(this.httpVersion), 
+		writeLine("%s %d %s",
+			getHTTPVersionString(this.httpVersion),
 			this.statusCode,
 			this.statusPhrase.length ? this.statusPhrase : httpStatusText(this.statusCode));
 
@@ -1190,7 +1190,7 @@ private void handleHTTPConnection(TCPConnection connection, HTTPServerListener l
 			break;
 		}
 	} while(!connection.empty);
-	
+
 	logTrace("Done handling connection.");
 }
 
@@ -1364,14 +1364,14 @@ private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTT
 		}
 
 		if (settings.options & HTTPServerOption.parseFormBody) {
-			auto ptype = "Content-Type" in req.headers;				
+			auto ptype = "Content-Type" in req.headers;
 			if (ptype) parseFormData(req.form, req.files, *ptype, req.bodyReader, MaxHTTPHeaderLineLength);
 		}
 
 		if (settings.options & HTTPServerOption.parseJsonBody) {
 			if (req.contentType == "application/json") {
 				auto bodyStr = cast(string)req.bodyReader.readAll();
-				if (!bodyStr.empty) req.json = parseJson(bodyStr);	
+				if (!bodyStr.empty) req.json = parseJson(bodyStr);
 			}
 		}
 
@@ -1425,8 +1425,8 @@ private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTT
 
 	foreach (k, v ; req.files) {
 		if (existsFile(v.tempPath)) {
-			removeFile(v.tempPath); 
-			logDebug("Deleted upload tempfile %s", v.tempPath.toString()); 
+			removeFile(v.tempPath);
+			logDebug("Deleted upload tempfile %s", v.tempPath.toString());
 		}
 	}
 
@@ -1465,7 +1465,7 @@ private void parseRequestHeader(HTTPServerRequest req, InputStream http_stream, 
 	reqln = reqln[pos+1 .. $];
 
 	req.httpVersion = parseHTTPVersion(reqln);
-	
+
 	//headers
 	parseRFC5322Header(stream, req.headers, MaxHTTPHeaderLineLength, alloc, false);
 
@@ -1474,7 +1474,7 @@ private void parseRequestHeader(HTTPServerRequest req, InputStream http_stream, 
 	logTrace("--------------------");
 }
 
-private void parseCookies(string str, ref CookieValueMap cookies) 
+private void parseCookies(string str, ref CookieValueMap cookies)
 {
 	while(str.length > 0) {
 		auto idx = str.indexOf('=');


### PR DESCRIPTION
This allows HTTPServerResponse and HTTPServerRequest to be subclassed, which allows much easier unittesting as `bodyWriter` can be overridden, which is as close to mocking/stubbing methods as we're going to get I think. 

I'm bringing this up, because I'm needing to subclass HTTPServerResponse with a dummy class rig that looks like this:

``` d
/*
 * Stub of ConnectionStream to satisfy HTTPServerResponse
 */
private final class NullConnStream : ConnectionStream {
    /// InputStream
    @property bool empty() { return true; }
    @property ulong leastSize() { return 0; }
    @property bool dataAvailableForRead() { return false; };
    const(ubyte)[] peek() { return []; };
    void read(ubyte[] dst) {};

    /// OutputStream
    void write(in ubyte[] bytes) {}
    void flush() {}
    void finalize() {}
    void write(InputStream stream, ulong nbytes = 0) {};

    // ConnectionStream
    @property bool connected() const { return false; }
    void close() {}
    bool waitForData(Duration timeout = 0.seconds) { return false; }
}

/*
 * Stub of HTTPServerResponse to override bodyWriter
 */
private final class DummyHTTPServerResponse : HTTPServerResponse {
private:
    AppenderOutputStream appender;

public:
    this() {
        super(
            new NullConnStream(),
            new NullConnStream(),
            null, null);
        appender = new AppenderOutputStream();
    }

    override @property OutputStream bodyWriter() {
        return appender;
    }

    string rendered() {
        return appender.data();
    }
}
```

in order to grab just the body that was written to the stream, in order to test that the body being written is correct. So, then I can use this rig like this:

``` d
unittest {
    auto resp = new DummyHTTPServerResponse();
    resp.renderTemple!`
        Something here
        <p>Something more here</p>
        <%= "<p>Escape me!</p>" %>
    `;

    assert(isSameRender(resp.rendered, `
        Something here
        <p>Something more here</p>
        &lt;p&gt;Escape me!&lt;/p&gt;
    `));
}
```

And, in general, it opens up the possibility for testing the request/response cycle from a higher level (although I don't believe there is currently any way to test the content of responses period). 
