### PR TITLE
fix broken keepAlive timeout

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1191,7 +1191,7 @@ private void handleHTTPConnection(TCPConnection connection, HTTPServerListener l
 		bool keep_alive;
 		handleRequest(http_stream, connection, listen_info, settings, keep_alive);
 		if (!keep_alive) { logTrace("No keep-alive"); break; }
-		if (connection.empty) { logTrace("Client disconnected."); break; }
+		if (!connection.connected) { logTrace("Client disconnected."); break; }
 
 		logTrace("Waiting for next request...");
 		// wait for another possible request on a keep-alive connection


### PR DESCRIPTION
problem with calling `empty` is that the libevent driver implementation of `empty` checks `leastSize` and `leastSize` is blocking without a timeout. this in turn renders the keepAlive timeout useless.
