### PR TITLE
fix failed http listener getting added to globals

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -155,9 +155,11 @@ private void listenHTTPPlain(HTTPServerSettings settings, HTTPServerRequestDeleg
 		}
 		if (!found_listener) {
 			auto listener = HTTPServerListener(addr, settings.port, settings.sslContext);
-			g_listeners ~= listener;
 			if (doListen(settings, listener, addr)) // DMD BUG 2043
+			{
 				any_succeeded = true;
+				g_listeners ~= listener;
+			}
 		}
 	}
 


### PR DESCRIPTION
doesn't it make more sense to just add a listener to the global list when it did not fail to start listening with it ?
