### PR TITLE
Access Violation in freeArray

### DIFF
--- a/source/vibe/utils/memory.d
+++ b/source/vibe/utils/memory.d
@@ -74,7 +74,7 @@ T[] allocArray(T, bool MANAGED = true)(shared(Allocator) allocator, size_t n)
 	return ret;
 }
 
-void freeArray(T, bool MANAGED = true)(shared(Allocator) allocator, ref T[] array)
+void freeArray(T, bool MANAGED = true)(shared(Allocator) allocator, T[] array)
 {
 	static if (MANAGED && hasIndirections!T)
 		GC.removeRange(array.ptr);


### PR DESCRIPTION
Sending array with ref causes an access violation. Top is with ref, below is some benchmarks - without ref

![2014-05-23 11_58_23-mingw32__e_dev_test](https://cloud.githubusercontent.com/assets/4785754/3068855/363f2f64-e293-11e3-96e7-0ab056f357bd.png)
