### PR TITLE
enable JSON-output in web.web Handlers

### DIFF
--- a/source/vibe/web/web.d
+++ b/source/vibe/web/web.d
@@ -410,7 +410,7 @@ private void handleRequest(string M, alias overload, C, ERROR...)(HTTPServerRequ
 	}
 
 	try {
-	        static if (is(RET : vibe.data.json.Json)) {
+	        static if (is(RET == vibe.data.json.Json)) {
 			res.writeJsonBody(__traits(getMember, instance, M)(params));
 		} else static if (is(RET : InputStream)) {
 			res.writeBody(__traits(getMember, instance, M)(params));


### PR DESCRIPTION
I recently needed to output json in a WebInterface.
I think this need is quite common, so I propose this change :D
