### PR TITLE
[trivial] Enquote host name in peer name failure verification warning.

### DIFF
--- a/source/vibe/stream/ssl.d
+++ b/source/vibe/stream/ssl.d
@@ -241,7 +241,7 @@ final class SSLStream : Stream {
 							version(Windows) import std.c.windows.winsock;
 							else import core.sys.posix.netinet.in_;
 
-							logWarn("peer name %s couldn't be verified, trying IP address.", vdata.peerName);
+							logWarn("peer name '%s' couldn't be verified, trying IP address.", vdata.peerName);
 							char* addr;
 							int addrlen;
 							switch (vdata.peerAddress.family) {


### PR DESCRIPTION
This makes it more obvious when the supplied peer name is empty.
