### PR TITLE
dmd ~master cannot compile vibe

### DIFF
--- a/source/vibe/core/concurrency.d
+++ b/source/vibe/core/concurrency.d
@@ -20,7 +20,10 @@ import vibe.core.task;
 import vibe.utils.memory;
 
 
-package enum newStdConcurrency = __VERSION__ >= 2066;
+// Workaround for master to compile.
+//package enum newStdConcurrency = __VERSION__ >= 2066;
+package enum newStdConcurrency = __traits(compiles, mixin("import std.concurrency : ThreadInfo, Tid;"));
+
 
 static if (newStdConcurrency) public import std.concurrency;
 else public import std.concurrency : MessageMismatch, OwnerTerminated, LinkTerminated, PriorityMessageException, MailboxFull, OnCrowding;


### PR DESCRIPTION
Currently, the FE is set at 2066, but D-Programming-Language/phobos#1910 isn't pulled yet, so it breaks the compilation.
Also, there is another issue, which currently prevent me from using vibe.d master, but it's more likely to be a compiler bug:

```
Compiling source/vibe/core/task.d...
Writing to: .dub/build/libevent-debug-linux.posix-x86_64-/tmp/result/bin/dmd-B8D9EA0D4C1B9C5BD0A7181866C46640/source.vibe.core.task.d.o
/tmp/result/bin/dmd -c -of.dub/build/libevent-debug-linux.posix-x86_64-/tmp/result/bin/dmd-B8D9EA0D4C1B9C5BD0A7181866C46640/source.vibe.core.task.d.o -debug -g -w -version=VibeLibeventDriver -version=Have_vibe_d -version=Have_libevent -version=Have_openssl -Isource/ -I../../../../.dub/packages/libevent-master -I../../../../.dub/packages/openssl-master source/vibe/core/task.d
source/vibe/core/task.d(105): Error: expression newStdConcurrency of type newStdConcurrency does not have a boolean value
source/vibe/core/task.d(136): Error: expression newStdConcurrency of type newStdConcurrency does not have a boolean value
source/vibe/core/core.d(1120): Error: FixedRingBuffer!CoreTask had previous errors
source/vibe/core/task.d(31): Error: expression newStdConcurrency of type newStdConcurrency does not have a boolean value
source/vibe/core/task.d(71): Error: expression newStdConcurrency of type newStdConcurrency does not have a boolean value
source/vibe/core/drivers/libevent2.d(582): Error: ArraySet!Task had previous errors
source/vibe/core/drivers/libevent2.d(585): Error: template instance vibe.utils.hashmap.HashMap!(Thread, ThreadSlot, DefaultHashMapTraits!(Thread)) error instantiating
FAIL .dub/build/libevent-debug-linux.posix-x86_64-/tmp/result/bin/dmd-B8D9EA0D4C1B9C5BD0A7181866C46640/ vibe-d staticLibrary
Error executing command build: /tmp/result/bin/dmd failed with exit code 1
```

I get this with ~master, gdc & dmd with FE 2065, and dmd v2.064.X doesn't even compile with digger.
_NOTE_: This is a tainted dub with implements `--build-mode=singleFile`. However, I work on this because in the first place, my shell script that did the same work hit the same problem. This only happen in `singleFile` mode, not in `allAtOnce` or `separate`.
