### PR TITLE
Fix missing import

### DIFF
--- a/source/vibe/internal/meta/funcattr.d
+++ b/source/vibe/internal/meta/funcattr.d
@@ -11,7 +11,7 @@
 
 module vibe.internal.meta.funcattr;
 
-import std.traits : isInstanceOf;
+import std.traits : isInstanceOf, ReturnType;
 
 /// example
 unittest


### PR DESCRIPTION
This compilation error happens if a method in web interface class has a return type.

```
vibe.d/source/vibe/internal/meta/funcattr.d(222): Error: template instance ReturnType!FUNCTION template 'ReturnType' is not defined
vibe.d/source/vibe/web/web.d(609): Error: template instance vibe.internal.meta.funcattr.evaluateOutputModifiers!(recent) error instantiating
```
