### PR TITLE
Added multiline response support

### DIFF
--- a/source/vibe/mail/smtp.d
+++ b/source/vibe/mail/smtp.d
@@ -206,8 +206,15 @@ private void expectStatus(InputStream conn, int expected_status, string in_respo
 	string ln = cast(string)conn.readLine();
 	auto sp = ln.indexOf(' ');
 	if( sp < 0 ) sp = ln.length;
-	auto status = to!int(ln[0 .. sp]);
-	enforce(status == expected_status, "Expected status "~to!string(expected_status)~" in response to "~in_response_to~", got "~to!string(status)~": "~ln[sp .. $]);
+	auto dsh = ln.indexOf('-');
+	if (dsh != -1 && dsh < sp)
+	{
+		expectStatus(conn, expected_status, in_response_to);
+	}
+	else {
+		auto status = to!int(ln[0 .. sp]);
+		enforce(status == expected_status, "Expected status "~to!string(expected_status)~" in response to "~in_response_to~", got "~to!string(status)~": "~ln[sp .. $]);
+	}
 }
 
 private int recvStatus(InputStream conn)


### PR DESCRIPTION
Follow-up of https://github.com/rejectedsoftware/vibe.d/issues/742

Here is the debug info before:

```
[BCEC0081:BCED3181 2014.07.27 20:57:57.769 dbg] Web handler postContactForm has thrown: std.conv.ConvException@/usr/share/src/phobos/std/conv.d(1689): Unexpected '-' when converting from type string to type int
[BCEC0081:BCED3181 2014.07.27 20:57:57.769 dbg] ----------------
[BCEC0081:BCED3181 2014.07.27 20:57:57.769 dbg] ./app(pure @safe int std.conv.to!(int).to!(immutable(char)[]).to(immutable(char)[])+0x20) [0x70c5b4]
[BCEC0081:BCED3181 2014.07.27 20:57:57.769 dbg] ./app(void vibe.mail.smtp.expectStatus(vibe.core.stream.InputStream, int, immutable(char)[])+0xbc) [0x7da798]
```

After:

```
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] EHLO response: 250-www.domain.com Hello localhost [127.0.0.1]
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] EHLO response: 250-SIZE 52428800
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] EHLO response: 250-8BITMIME
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] EHLO response: 250-PIPELINING
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] EHLO response: 250-AUTH PLAIN LOGIN
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] EHLO response: 250-STARTTLS
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] EHLO response: 250 HELP
[230D30E5:230E61E5 2014.07.28 15:28:25.885 dbg] seding auth
[230D30E5:230E61E5 2014.07.28 15:28:25.886 dbg] seding auth info
[230D30E5:230E61E5 2014.07.28 15:28:25.927 dbg] authed
```

This is with dovecot, which is de facto on many servers. I think gmail also communicates this way, 

```
openssl s_client -connect smtp.gmail.com:465 -crlf -ign_eof
[... lots of openssl output ...]
220 mx.google.com ESMTP m46sm11546481eeh.9
EHLO localhost
250-mx.google.com at your service, [1.2.3.4]
250-SIZE 35882577
250-8BITMIME
250-AUTH LOGIN PLAIN XOAUTH
250 ENHANCEDSTATUSCODES
AUTH PLAIN AG5pY2UudHJ5QGdtYWlsLmNvbQBub2l0c25vdG15cGFzc3dvcmQ=
235 2.7.0 Accepted
```
