### PR TITLE
Support ubyte[] as a redis reply type

### DIFF
--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -857,7 +857,7 @@ private final class RedisConnection {
 			} else static if (isArray!A) {
 				foreach (arg; args[i])
 					writeArgs(dst, arg);
-			} else static assert(false, "Unsupported Redis argument type: " ~ T.stringof);
+			} else static assert(false, "Unsupported Redis argument type: " ~ A.stringof);
 		}
 	}
 
@@ -927,6 +927,6 @@ private T _request(T, ARGS...)(LockedConnection!RedisConnection conn, string com
 		auto result = reply.next!string();
 		return parse!T(result);
 	}
-	else static if (is(T == string)) return reply.next!string();
+	else static if (is(T == string) || is (T == ubyte[])) return reply.next!T();
 	else static assert(is(T == void), "Unsupported Redis reply type: " ~ T.stringof);
 }


### PR DESCRIPTION
ubyte arrays can be stored, but cannot be taken from a database directly.

``` d
ubyte[] arr = [0, 1, 2, 3, 4, 5];
db.set("key", arr); // ok

auto ret = db.get!(ubyte[])("key"); // Unsupported Redis reply type
```
