### PR TITLE
Turn static void array into ubyte one

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1141,8 +1141,8 @@ private struct ThreadContext {
 
 private struct TaskFuncInfo {
 	void function(TaskFuncInfo*) func;
-	void[2*size_t.sizeof] callable;
-	void[maxTaskParameterSize] args;
+	void[2*size_t.sizeof] callable = void;
+	void[maxTaskParameterSize] args = void;
 }
 
 alias TaskArgsVariant = VariantN!maxTaskParameterSize;


### PR DESCRIPTION
I am surprised this compiles with `dmd` but latest LDC alpha (also 2.065 frontend) reports:

```
Running ldmd2...
../../../../.dub/packages/vibe-d-0.7.21-alpha.3/source/vibe/core/core.d(1144): Error: static arrays of voids have no default initializer
```

Which makes sense. `void` does not have any size and having static array of those is totally undefined.
