### PR TITLE
Added timeout non-zero verification - fixes #776

### DIFF
--- a/tests/redis/dub.json
+++ b/tests/redis/dub.json
@@ -4,5 +4,5 @@
     "dependencies": {
         "vibe-d": {"version": "~master", "path": "../../"}
     },
-    "versions": ["VibeCustomMain", "RedisDebug"]
+    "versions": ["VibeCustomMain"]
 }

--- a/tests/redis/source/app.d
+++ b/tests/redis/source/app.d
@@ -67,8 +67,8 @@ void runTest()
 		logInfo("LISTEN Recv Channel: %s, Message: %s", channel.to!string, msg.to!string);
 		logInfo("LISTEN Recv Time: %s", Clock.currTime().toString());
 	});
-
 	assert(sub.isListening);
+	sleep(1.seconds);
 	sub.subscribe("SomeChannel");
 
 	logInfo("PUBLISH Sent: %s", Clock.currTime().toString());
@@ -84,7 +84,7 @@ void runTest()
 
 int main()
 {
-	int ret = 0;
+	int ret = 0; 
 	runTask({
 		try runTest();
 		catch (Throwable th) {


### PR DESCRIPTION
The pubsub listener was making the `bstop` call wait forever, because it was never listening in the first place: the 0 second `Duration` timeout was being triggered, rather than being considered as a "no timeout" value.
