### PR TITLE
Fix `RedisClient` instantiation for authentication

### DIFF
--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -30,7 +30,6 @@ RedisClient connectRedis(string host, ushort port = 6379)
 	return new RedisClient(host, port);
 }
 
-
 /**
 	A redis client with connection pooling.
 */
@@ -47,23 +46,29 @@ final class RedisClient {
 		m_connections = new ConnectionPool!RedisConnection({
 			return new RedisConnection(host, port);
 		});
-
-		import std.string;
-		auto info = info();
-		auto lines = info.splitLines();
-		if (lines.length > 1) {
-			foreach (string line; lines) {
-				auto lineParams = line.split(":");
-				if (lineParams.length > 1 && lineParams[0] == "redis_version") {
-					m_version = lineParams[1];
-					break;
-				}
-			}
-		} 
 	}
 
 	/// Returns Redis version
-	@property string redisVersion() { return m_version; }
+	@property string redisVersion()
+	{
+		if(!m_version)
+		{
+			import std.string;
+			auto info = info();
+			auto lines = info.splitLines();
+			if (lines.length > 1) {
+				foreach (string line; lines) {
+					auto lineParams = line.split(":");
+					if (lineParams.length > 1 && lineParams[0] == "redis_version") {
+						m_version = lineParams[1];
+						break;
+					}
+				}
+			}
+		}
+
+		return m_version;
+	}
 
 	/** Returns a handle to the given database.
 	*/


### PR DESCRIPTION
This removes the "INFO" command from the default `RedisClient`
constructor, since its only there to support the `redisVersion` getter.
This fixes creating clients for databases that require authentication
for all commands. It moves the version fetching logic into the
`redisVersion` getter, and caches its result in the `m_version`
property. I think this is the cleanest solution to this issue.
