### PR TITLE
Trivial: Allow "identity" conent-encoding in HTTP client

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -748,7 +748,7 @@ final class HTTPClientResponse : HTTPResponse {
 				m_gzipInputStream = FreeListRef!GzipInputStream(m_bodyReader);
 				m_bodyReader = m_gzipInputStream;
 			}
-			else enforce(false, "Unsuported content encoding: "~*pce);
+			else enforce(*pce == "identity", "Unsuported content encoding: "~*pce);
 		}
 
 		// be sure to free resouces as soon as the response has been read


### PR DESCRIPTION
"identity" should not be used in Content-Encoding header, but some libraries/servers respond it.
