### PR TITLE
Fixed worker thread silent assertions

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1350,13 +1350,20 @@ private void setupWorkerThreads()
 
 private void workerThreadFunc()
 {
-	assert(s_core !is null);
-	if (getExitFlag()) return;
-	logDebug("entering worker thread");
-	runTask(toDelegate(&handleWorkerTasks));
-	logDebug("running event loop");
-	if (!getExitFlag()) runEventLoop();
-	logDebug("Worker thread exit.");
+	try {
+		assert(s_core !is null);
+		if (getExitFlag()) return;
+		logDebug("entering worker thread");
+		runTask(toDelegate(&handleWorkerTasks));
+		logDebug("running event loop");
+		if (!getExitFlag()) runEventLoop();
+		
+		logDebug("Worker thread exit.");	
+	}
+	catch (Throwable e) {
+		logError(e.toString());
+		exitEventLoop(true);
+	}
 }
 
 private void handleWorkerTasks()


### PR DESCRIPTION
All worker threads are currently silent when assertions are thrown outside of tasks. This fix closes the event loops from other worker threads when one of them errors out, and logs the error appropriately.