### PR TITLE
Fix (de)serialization of aggregate types with functions returning by ref

### DIFF
--- a/source/vibe/data/serialization.d
+++ b/source/vibe/data/serialization.d
@@ -951,3 +951,20 @@ unittest // Testing corner case: Variadic template constructors and methods
 	auto s = S(1);
 	assert(s.serializeToJson().deserializeJson!S() == s);
 }
+
+unittest // Make sure serializing through properties still works
+{
+	import vibe.data.json;
+
+	static struct S
+	{
+		public int i;
+		private int privateJ;
+
+		@property int j() { return privateJ; }
+		@property void j(int j) { privateJ = j; }
+	}
+
+	auto s = S(1, 2);
+	assert(s.serializeToJson().deserializeJson!S() == s);
+}


### PR DESCRIPTION
This fixes a number of corner cases present in the serialization module, original report is issue #802
