### PR TITLE
Fix isPublicMember for private members

### DIFF
--- a/source/vibe/internal/meta/traits.d
+++ b/source/vibe/internal/meta/traits.d
@@ -234,7 +234,7 @@ template isPublicMember(T, string M)
 {
 	import std.algorithm;
 
-	static if (!__traits(compiles, __traits(getMember, T.init, M))) enum isPublicMember = false;
+	static if (!__traits(compiles, TypeTuple!(__traits(getMember, T, M)))) enum isPublicMember = false;
 	else {
 		alias MEM = TypeTuple!(__traits(getMember, T, M));
 		enum isPublicMember = __traits(getProtection, MEM).among("public", "export");


### PR DESCRIPTION
Currently isPublicMember is broken for private functions. The unittests are only passing because private means module private. Structs from other modules result in

> source\vibe\internal\meta\traits.d(236): Error: struct app.S member foo is not accessible

Unlike my previous attempt, this should work on both 2.065 and 2.066
