### PR TITLE
Return "Bad Request" for errors caused by client

### DIFF
--- a/source/vibe/http/auth/basic_auth.d
+++ b/source/vibe/http/auth/basic_auth.d
@@ -28,7 +28,7 @@ HTTPServerRequestDelegate performBasicAuth(string realm, bool delegate(string us
 			string user_pw = cast(string)Base64.decode((*pauth)[6 .. $]);
 
 			auto idx = user_pw.indexOf(":");
-			enforce(idx >= 0, "Invalid auth string format!");
+			enforceBadRequest(idx >= 0, "Invalid auth string format!");
 			string user = user_pw[0 .. idx];
 			string password = user_pw[idx+1 .. $];
 
@@ -69,7 +69,7 @@ string performBasicAuth(HTTPServerRequest req, HTTPServerResponse res, string re
 		string user_pw = cast(string)Base64.decode((*pauth)[6 .. $]);
 
 		auto idx = user_pw.indexOf(":");
-		enforce(idx >= 0, "Invalid auth string format!");
+		enforceBadRequest(idx >= 0, "Invalid auth string format!");
 		string user = user_pw[0 .. idx];
 		string password = user_pw[idx+1 .. $];
 

--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -107,6 +107,14 @@ void enforceHTTP(T)(T condition, HTTPStatus statusCode, string message = null)
 	enforce(condition, new HTTPStatusException(statusCode, message));
 }
 
+/**
+	Utility function that throws a HTTPStatusException with status code "400 Bad Request" if the _condition is not met.
+*/
+void enforceBadRequest(T)(T condition, string message = null)
+{
+	enforceHTTP(condition, HTTPStatus.badRequest, message);
+}
+
 
 /**
 	Represents an HTTP request made to a server.
@@ -285,14 +293,14 @@ string getHTTPVersionString(HTTPVersion ver)
 
 HTTPVersion parseHTTPVersion(ref string str)
 {
-	enforce(str.startsWith("HTTP/"));
+	enforceBadRequest(str.startsWith("HTTP/"));
 	str = str[5 .. $];
 	int majorVersion = parse!int(str);
-	enforce(str.startsWith("."));
+	enforceBadRequest(str.startsWith("."));
 	str = str[1 .. $];
 	int minorVersion = parse!int(str);
 	
-	enforce( majorVersion == 1 && (minorVersion == 0 || minorVersion == 1) );
+	enforceBadRequest( majorVersion == 1 && (minorVersion == 0 || minorVersion == 1) );
 	return minorVersion == 0 ? HTTPVersion.HTTP_1_0 : HTTPVersion.HTTP_1_1;
 }
 
@@ -327,9 +335,9 @@ final class ChunkedInputStream : InputStream {
 
 	void read(ubyte[] dst)
 	{
-		enforce(!empty, "Read past end of chunked stream.");
+		enforceBadRequest(!empty, "Read past end of chunked stream.");
 		while( dst.length > 0 ){
-			enforce(m_bytesInCurrentChunk > 0, "Reading past end of chunked HTTP stream.");
+			enforceBadRequest(m_bytesInCurrentChunk > 0, "Reading past end of chunked HTTP stream.");
 
 			auto sz = cast(size_t)min(m_bytesInCurrentChunk, dst.length);
 			m_in.read(dst[0 .. sz]);
@@ -340,7 +348,7 @@ final class ChunkedInputStream : InputStream {
 				// skip current chunk footer and read next chunk
 				ubyte[2] crlf;
 				m_in.read(crlf);
-				enforce(crlf[0] == '\r' && crlf[1] == '\n');
+				enforceBadRequest(crlf[0] == '\r' && crlf[1] == '\n');
 				readChunk();
 			}
 		}
@@ -360,7 +368,7 @@ final class ChunkedInputStream : InputStream {
 			// skip final chunk footer
 			ubyte[2] crlf;
 			m_in.read(crlf);
-			enforce(crlf[0] == '\r' && crlf[1] == '\n');
+			enforceBadRequest(crlf[0] == '\r' && crlf[1] == '\n');
 		}
 	}
 }

--- a/source/vibe/http/form.d
+++ b/source/vibe/http/form.d
@@ -204,7 +204,7 @@ private HTTPServerRequestDelegate formMethodHandler(DelegateType)(DelegateType f
 	void handler(HTTPServerRequest req, HTTPServerResponse res)
 	{
 		string error;
-		enforce(applyParametersFromAssociativeArray(req, res, func, error, strict), error);
+		enforceBadRequest(applyParametersFromAssociativeArray(req, res, func, error, strict), error);
 	}
 	return &handler;
 }
@@ -232,7 +232,7 @@ private HTTPServerRequestDelegate formMethodHandler(T, string method)(T inst, Fl
 			}
 			errors~="Overload "~method~typeid(ParameterTypeTuple!func).toString()~" failed: "~error~"\n\n";
 		}
-		enforce(false, "No method found that matches the found form data:\n"~errors);
+		enforceBadRequest(false, "No method found that matches the found form data:\n"~errors);
 	}
 	return &handler;
 }
@@ -449,7 +449,7 @@ struct StringLengthCountingRange {
 		// We have a default value for country if not provided, so we don't care that it is not:
 		p.address.country="Important Country";
 		p.name="Jane";
-		enforce(loadFormData(req, p, "customer"), "More data than needed provided!");
+		enforceBadRequest(loadFormData(req, p, "customer"), "More data than needed provided!");
 		// p will now contain the provided form data, non provided data stays untouched.
 		assert(p.address.country=="Important Country");
 		assert(p.name=="John");

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1351,11 +1351,11 @@ private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTT
 		if (auto pcl = "Content-Length" in req.headers) {
 			string v = *pcl;
 			auto contentLength = parse!ulong(v); // DMDBUG: to! thinks there is a H in the string
-			enforce(v.length == 0, "Invalid content-length");
-			enforce(settings.maxRequestSize <= 0 || contentLength <= settings.maxRequestSize, "Request size too big");
+			enforceBadRequest(v.length == 0, "Invalid content-length");
+			enforceBadRequest(settings.maxRequestSize <= 0 || contentLength <= settings.maxRequestSize, "Request size too big");
 			limited_http_input_stream = FreeListRef!LimitedHTTPInputStream(reqReader, contentLength);
 		} else if (auto pt = "Transfer-Encoding" in req.headers) {
-			enforce(*pt == "chunked");
+			enforceBadRequest(*pt == "chunked");
 			chunked_input_stream = FreeListRef!ChunkedInputStream(reqReader);
 			limited_http_input_stream = FreeListRef!LimitedHTTPInputStream(chunked_input_stream, settings.maxRequestSize, true);
 		} else {
@@ -1506,13 +1506,13 @@ private void parseRequestHeader(HTTPServerRequest req, InputStream http_stream, 
 
 	//Method
 	auto pos = reqln.indexOf(' ');
-	enforce(pos >= 0, "invalid request method");
+	enforceBadRequest(pos >= 0, "invalid request method");
 
 	req.method = httpMethodFromString(reqln[0 .. pos]);
 	reqln = reqln[pos+1 .. $];
 	//Path
 	pos = reqln.indexOf(' ');
-	enforce(pos >= 0, "invalid request path");
+	enforceBadRequest(pos >= 0, "invalid request path");
 
 	req.requestURL = reqln[0 .. pos];
 	reqln = reqln[pos+1 .. $];
@@ -1531,7 +1531,7 @@ private void parseCookies(string str, ref CookieValueMap cookies)
 {
 	while(str.length > 0) {
 		auto idx = str.indexOf('=');
-		enforce(idx > 0, "Expected name=value.");
+		enforceBadRequest(idx > 0, "Expected name=value.");
 		string name = str[0 .. idx].strip();
 		str = str[idx+1 .. $];
 

--- a/source/vibe/web/common.d
+++ b/source/vibe/web/common.d
@@ -591,7 +591,7 @@ package T webConvTo(T)(string str)
 	static if (is(typeof(T.fromStringValidate(str, &error)))) {
 		static assert(is(typeof(T.fromStringValidate(str, &error)) == Nullable!T));
 		auto ret = T.fromStringValidate(str, &error);
-		enforce(!ret.isNull(), error); // TODO: refactor internally to work without exceptions
+		enforceBadRequest(!ret.isNull(), error); // TODO: refactor internally to work without exceptions
 		return ret.get();
 	} else static if (is(typeof(T.fromString(str)))) {
 		static assert(is(typeof(T.fromString(str)) == T));


### PR DESCRIPTION
Currently, `enforce()` is used to check for invalid requests to the server, for example malformed HTTP queries, or missing/wrongly typed query parameters in APIs. `enforce()` throws a generic `Exception`, which makes the server return `500 Internal Server Error` to the client. However, the appropriate response for invalid requests is `400 Bad Request`.
