### PR TITLE
Use `thisProcessID` instead of deprecated `getpid()`

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -707,7 +707,7 @@ struct BsonObjectID {
 		import std.process;
 		import std.random;
 
-		if( ms_pid == -1 ) ms_pid = getpid();
+		if( ms_pid == -1 ) ms_pid = thisProcessID;
 		if( MACHINE_ID == 0 ) MACHINE_ID = uniform(0, 0xffffff);
 
 		BsonObjectID ret = void;


### PR DESCRIPTION
Fixes deprecation warning:

```
source/vibe/data/bson.d(710): Deprecation: alias std.process.getpid is deprecated - Please use thisProcessID instead
```
