### PR TITLE
Bring vibe.d's enforce closer to std.exception.enforce

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -102,17 +102,17 @@ unittest
 /**
 	Utility function that throws a HTTPStatusException if the _condition is not met.
 */
-void enforceHTTP(T)(T condition, HTTPStatus statusCode, string message = null)
+T enforceHTTP(T)(T condition, HTTPStatus statusCode, lazy string message = null)
 {
-	enforce(condition, new HTTPStatusException(statusCode, message));
+	return enforce(condition, new HTTPStatusException(statusCode, message));
 }
 
 /**
 	Utility function that throws a HTTPStatusException with status code "400 Bad Request" if the _condition is not met.
 */
-void enforceBadRequest(T)(T condition, string message = null)
+T enforceBadRequest(T)(T condition, lazy string message = null)
 {
-	enforceHTTP(condition, HTTPStatus.badRequest, message);
+	return enforceHTTP(condition, HTTPStatus.badRequest, message);
 }
 
 


### PR DESCRIPTION
(1) Use of lazy const(char)[] instead of string -> No more eager format() call;
(2) Return the value computed;

There are some low-hanging fruit for (2), like [here](https://github.com/rejectedsoftware/vibe.d/blob/master/source/vibe/web/rest.d#L543) (P.R for them to come soon)
