### PR TITLE
Refcounted SSL stream goes out of scope - fixes #846

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1202,6 +1202,11 @@ private void handleHTTPConnection(TCPConnection connection, HTTPServerListener l
 {
 	Stream http_stream = connection;
 
+	version(VibeNoSSL) {} else {
+		import std.traits : ReturnType;
+		ReturnType!createSSLStreamFL ssl_stream;
+	}
+
 	if (!connection.waitForData(10.seconds())) {
 		logDebug("Client didn't send the initial request in a timely manner. Closing connection.");
 		return;
@@ -1211,8 +1216,6 @@ private void handleHTTPConnection(TCPConnection connection, HTTPServerListener l
 	if (listen_info.sslContext) {
 		version (VibeNoSSL) assert(false, "No SSL support compiled in (VibeNoSSL)");
 		else {
-			import std.traits : ReturnType;
-			ReturnType!createSSLStreamFL ssl_stream;
 			logTrace("accept ssl");
 			// TODO: reverse DNS lookup for peer_name of the incoming connection for SSL client certificate verification purposes
 			ssl_stream = createSSLStreamFL(http_stream, listen_info.sslContext, SSLStreamState.accepting, null, connection.remoteAddress);


### PR DESCRIPTION
Error occurs when requesting a page in the https_server example
