### PR TITLE
Remove useless version tag, forces complete re-compilation

### DIFF
--- a/examples/serialization/dub.json
+++ b/examples/serialization/dub.json
@@ -5,5 +5,5 @@
 	"dependencies": {
 		"vibe-d": {"version": "~master", "path": "../../"}
 	},
-	"versions": ["VibeCustomMain", "VibeNewSerialization"]
+	"versions": ["VibeCustomMain"]
 }


### PR DESCRIPTION
This causes some travis builds to fail because of excessive memory use from repeatedly recompiling different vibe-d library for examples. Additionally, I couldn't find any reference to this version tag in the code.
