### PR TITLE
Avoid files from polluting the vibe folder when unit tests are run

### DIFF
--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -591,6 +591,7 @@ final class SyslogLogger : Logger {
 		assert(lines[4] == "<139>1 0000-01-01T00:00:00.000001 - " ~ BOM ~ "appname - - - " ~ BOM ~ "αβγ\n");
 		assert(lines[5] == "<138>1 0000-01-01T00:00:00.000001 - " ~ BOM ~ "appname - - - " ~ BOM ~ "αβγ\n");
 		assert(lines[6] == "<137>1 0000-01-01T00:00:00.000001 - " ~ BOM ~ "appname - - - " ~ BOM ~ "αβγ\n");
+		removeFile(fstream.path().toNativeString());
 	}
 }
 


### PR DESCRIPTION
The `dub test` builds leave behind some randomly named files in the folder. This fixes the issue
