### PR TITLE
Add sleepers to reflect real directory behavior

### DIFF
--- a/tests/dirwatcher/source/app.d
+++ b/tests/dirwatcher/source/app.d
@@ -1,5 +1,6 @@
 import vibe.vibe;
 import std.file, std.process;
+import std.algorithm : canFind, all;
 
 void runTest()
 {
@@ -20,22 +21,25 @@ void runTest()
 
 	alias Type = DirectoryChangeType;
 	static DirectoryChange dc(Type t, string p) { return DirectoryChange(t, Path(p)); }
-
 	void check(DirectoryChange[] expected)
 	{
-		assert(watcher.readChanges(changes, 0.seconds));
-		assert(changes == expected);
-		assert(!watcher.readChanges(changes, 100.msecs));
+		sleep(100.msecs);
+		assert(watcher.readChanges(changes, 100.msecs), "Could not read changes for " ~ expected.to!string);
+		assert(expected.all!((a)=> changes.canFind(a))(), "Change is not what was expected, got: " ~ changes.to!string ~ " but expected: " ~ expected.to!string);
+		assert(!watcher.readChanges(changes, 0.msecs), "Changes were returned when they shouldn't have, for " ~ expected.to!string);
 	}
 
 	write(foo, null);
 	check([dc(Type.added, foo)]);
+	sleep(1.seconds); // OSX has a second resolution on file modification times
 	write(foo, [0, 1]);
 	check([dc(Type.modified, foo)]);
 	remove(foo);
 	check([dc(Type.removed, foo)]);
 	write(foo, null);
+	sleep(1.seconds);
 	write(foo, [0, 1]);
+	sleep(100.msecs);
 	remove(foo);
 	check([dc(Type.added, foo), dc(Type.modified, foo), dc(Type.removed, foo)]);
 
@@ -46,21 +50,28 @@ void runTest()
 	write(bar, null);
 	assert(!watcher.readChanges(changes, 100.msecs));
 	remove(bar);
-
 	watcher = Path(dir).watchDirectory(Yes.recursive);
 	write(foo, null);
+	sleep(1.seconds); 
 	write(foo, [0, 1]);
+	sleep(100.msecs);
 	remove(foo);
+
 	write(bar, null);
+	sleep(1.seconds); 
 	write(bar, [0, 1]);
+	sleep(100.msecs);
 	remove(bar);
 	check([dc(Type.added, foo), dc(Type.modified, foo), dc(Type.removed, foo),
 		 dc(Type.added, bar), dc(Type.modified, bar), dc(Type.removed, bar)]);
 
 	write(foo, null);
+	sleep(100.msecs);
 	rename(foo, bar);
+	sleep(100.msecs);
 	remove(bar);
 	check([dc(Type.added, foo), dc(Type.removed, foo), dc(Type.added, bar), dc(Type.removed, bar)]);
+
 }
 
 int main()


### PR DESCRIPTION
This test fix is in preparation for the async library, which doesn't necessarily notify of directory changes all at once within nanoseconds. It could take a few milliseconds though
