### PR TITLE
Fixes issue #868

### DIFF
--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -1389,7 +1389,7 @@ struct JsonStringSerializer(R, bool pretty = false)
 		size_t m_level = 0;
 	}
 
-	template isJsonBasicType(T) { enum isJsonBasicType = is(T : long) || is(T : real) || is(T == string) || is(T == typeof(null)) || isJsonSerializable!T; }
+	template isJsonBasicType(T) { enum isJsonBasicType = isNumeric!T || isBoolean!T || is(T == string) || is(T == typeof(null)) || isJsonSerializable!T; }
 
 	template isSupportedValueType(T) { enum isSupportedValueType = isJsonBasicType!T || is(T == Json); }
 


### PR DESCRIPTION
`JsonStringSerializer.isSupportedValueType!(Nullable!T)` equals `true` if `T` is numeric type.
This causes `serializeImpl` to call `JsonStringSerializer.writeValue` which fails If `Nullable!T` is empty.
