### PR TITLE
Slight improvement to the docs

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -203,7 +203,7 @@ private void listenHTTPPlain(HTTPServerSettings settings)
 
 	Params:
 		url = The URL to redirect to
-		status = Redirection status to use (by default this is $(D HTTPStatus.found)
+		status = Redirection status to use $(LPAREN)by default this is $(D HTTPStatus.found)$(RPAREN).
 
 	Returns:
 		Returns a $(D HTTPServerRequestDelegate) that performs the redirect

--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -7,8 +7,6 @@
 */
 module vibe.http.websockets;
 
-alias WebSocketHandshakeDelegate = void delegate(scope WebSocket);
-
 ///
 unittest {
 	void handleConn(scope WebSocket sock)
@@ -29,6 +27,8 @@ unittest {
 		// Start HTTP server using listenHTTP()...
 	}
 }
+
+alias WebSocketHandshakeDelegate = void delegate(scope WebSocket);
 
 import vibe.core.core;
 import vibe.core.log;

--- a/source/vibe/utils/string.d
+++ b/source/vibe/utils/string.d
@@ -130,7 +130,7 @@ sizediff_t indexOfAny(string str, string chars)
 alias countUntilAny = indexOfAny;
 
 /**
-	Finds the closing bracket (works with any of '[', '(', '<', '{').
+	Finds the closing bracket (works with any of '[', '$(LPAREN)', '<', '{').
 
 	Params:
 		str = input string

--- a/source/vibe/web/rest.d
+++ b/source/vibe/web/rest.d
@@ -54,9 +54,8 @@ import std.algorithm : startsWith, endsWith;
 		instance = Class instance to use for the REST mapping - Note that TImpl
 			must either be an interface type, or a class which derives from a
 			single interface
-		url_prefix = Optional path prefix to use when registering the HTTP routes
-		style = The naming convention to use for the translation of method names
-			to HTTP paths
+		settings = Additional settings, such as the $(D MethodStyle), or the prefix.
+                           See $(D RestInterfaceSettings) for more details.
 
 	See_Also:
 		$(D RestInterfaceClient) class for a seamless way to access such a generated API


### PR DESCRIPTION
Fix few warnings when building the docs (the others being false-positive).

Also, what's the way to deal with the `$(D ...)` macro ?
It doesn't seem to be documented in http://dlang.org/ddoc.html
I thought it was for D keyword, but `source.vibe.http.server` L206 use it for an XREF. So how should it be used (as it's currently inconsistent in the doc).
