### PR TITLE
Accepting scoped default initialization

### DIFF
--- a/source/vibe/utils/memory.d
+++ b/source/vibe/utils/memory.d
@@ -660,7 +660,15 @@ struct FreeListRef(T, bool INIT = true)
 	}
 
 	@property const(TR) get() const { checkInvariants(); return m_object; }
-	@property TR get() { checkInvariants(); return m_object; }
+	@property TR get() 
+	{ 
+		static if (__traits(compiles, new TR()))
+			if (!m_object)
+				this = opCall();
+		checkInvariants();
+		return m_object; 
+	}
+
 	alias get this;
 
 	private @property ref int refCount()

--- a/source/vibe/utils/memory.d
+++ b/source/vibe/utils/memory.d
@@ -662,7 +662,7 @@ struct FreeListRef(T, bool INIT = true)
 	@property const(TR) get() const { checkInvariants(); return m_object; }
 	@property TR get() 
 	{ 
-		static if (__traits(compiles, new TR()))
+		static if (INIT && __traits(compiles, new TR()))
 			if (!m_object)
 				this = opCall();
 		checkInvariants();


### PR DESCRIPTION
I'm currently trying to carry over scoped default declaration/initializations of class (inheritance) objects from C++.

This minor modifications seems to fit the bill pretty well, although I could probably use this in `scoped!` objects.

Here's how it looks:

	import vibe.utils.memory;
	import std.stdio;
	class A { void print() { writeln("A"); } }
	class B : A { override void print() { writeln("B"); } }
	void print(A a) { a.print(); }
	void main()
	{
		FreeListRef!B b;
		print(b);
	}

This prints `B`, whereas without the change in this pull request, the above code triggered a memory error.