### PR TITLE
Fix Websocket pinging.

### DIFF
--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -503,8 +503,12 @@ final class IncomingWebSocketMessage : InputStream {
 					m_currentFrame = frame;
 					break;
 				case FrameOpcode.ping:
-					frame.opcode = FrameOpcode.pong;
-					frame.writeFrame(m_conn);
+					Frame pong;
+					pong.opcode = FrameOpcode.pong;
+					pong.fin = true;
+					pong.payload = frame.payload;
+
+					pong.writeFrame(m_conn);
 					break;
 				default:
 					throw new WebSocketException("unknown frame opcode");


### PR DESCRIPTION
When vibe.d received a ping frame, it set the frame's opcode to pong and sent the pong message, it broke out of the switch and the loop as well (since the opcode is no longer ping), which left the m_currentFrame in a zeroed out state so Websocket receive complained about unexpected continuation frame and closed the connection.

Heartbeat made the connection go away - sweet irony.
