### PR TITLE
Wrapping email address inside angle brackets.

### DIFF
--- a/source/vibe/mail/smtp.d
+++ b/source/vibe/mail/smtp.d
@@ -259,7 +259,7 @@ private int recvStatus(InputStream conn)
 private string addressMailPart(string str)
 {
 	auto idx = str.indexOf('<');
-	if( idx < 0 ) return str;
+	if( idx < 0 ) return "<"~ str ~">";
 	str = str[idx .. $];
 	enforce(str[$-1] == '>', "Malformed email address field: '"~str~"'.");
 	return str;


### PR DESCRIPTION
Both smtp.zoho.com and smtp.gmail.com refuse to go through if an email address is not wrapped inside angle brackets...
The problem hits when sending mail through userman. Should it be fixed in userman or in vibe, your call. 

thx.
