### PR TITLE
Use freeArray in HashMap destructor

### DIFF
--- a/source/vibe/utils/hashmap.d
+++ b/source/vibe/utils/hashmap.d
@@ -45,7 +45,7 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 
 	~this()
 	{
-		if (m_table) m_allocator.free(cast(void[])m_table);
+		if (m_table) freeArray(m_allocator, m_table);
 	}
 
 	@disable this(this);


### PR DESCRIPTION
This ensures destructors are called on the elements in the hash map. I'm not sure if this fixes anything but it seemed like it could have caused issues eventually.
