### PR TITLE
Allow Exception object in _error struct.

### DIFF
--- a/source/vibe/web/web.d
+++ b/source/vibe/web/web.d
@@ -557,7 +557,7 @@ private void handleRequest(string M, alias overload, C, ERROR...)(HTTPServerRequ
 				params[i].setVoid(computeAttributedParameterCtx!(overload, param_names[i])(instance, req, res));
 				if (res.headerWritten) return;
 			}
-			else static if (param_names[i] == "_error"){
+			else static if (param_names[i] == "_error") {
 				static if (ERROR.length == 1)
 					params[i].setVoid(error[0]);
 				else static if (!is(default_values[i] == void))


### PR DESCRIPTION
Hi.
I tried to do something like:

```
struct ErrInfo
{
    Exception error;
    string field;
}
void getList(ErrInfo _error) {...}
@errorDisplay!getList
void postNew() {...}
```

ErrorDisplayAttribute.getError allow fill Exception object in _error struct.
But if there is no error information, HandleRequest trying to read _error from  req.params.
And it fails because webConvTo can not handle this struct.
This pull request fixes this. But now _error not be read from req.params at all. And now _error can not have default value.
I think that the _error parameter is enough internally, to behave this way. But I'm not entirely sure.
Thanks!
