### PR TITLE
Allow findAndModify to take an options parameter: BREAKING CHANGE

### DIFF
--- a/source/vibe/db/mongo/collection.d
+++ b/source/vibe/db/mongo/collection.d
@@ -198,19 +198,14 @@ struct MongoCollection {
 	  Throws Exception if a DB communication error occured.
 	  See_Also: $(LINK http://docs.mongodb.org/manual/reference/command/findAndModify)
 	 */
-	Bson findAndModify(T, U, V)(T query, U update, V returnFieldSelector)
+	Bson findAndModify(T, U, V)(T query, U update, V options)
 	{
-		static struct CMD {
-			string findAndModify;
-			T query;
-			U update;
-			V fields;
-		}
-		CMD cmd;
+		auto cmd = Bson.emptyObject;
 		cmd.findAndModify = m_name;
 		cmd.query = query;
 		cmd.update = update;
-		cmd.fields = returnFieldSelector;
+		static if (!is(V == typeof(null))) 
+			foreach(key, value; options) cmd[key] = value;
 		auto ret = database.runCommand(cmd);
 		if( !ret.ok.get!double ) throw new Exception("findAndModify failed.");
 		return ret.value;


### PR DESCRIPTION
The third parameter to findAndModify was previously set as the returnFieldSelector. The problem with this is that the findAndModify function in mongo takes quite a large number of optional parameters, such as the very commonly used "new" parameter.

This fix replaces the third parameter with an options argument which should take anything that can be iterated as an associative array (such as a Json or Bson object)

Example:

```D
auto result = collection.findAndModify(
    ["_id": Bson(_id), "count": Bson(count)],
    ["$inc": Bson(["count": Bson(1)],
    ["new": true]
);
```

To achieve this, I have strayed away from using the CMD struct, but the struct doesn't allow for optional parameters.