### PR TITLE
Fix problems deserializing Bson long into int

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -1471,7 +1471,10 @@ struct BsonSerializer {
 		else static if (is(T == bool)) return m_inputData.get!bool();
 		else static if (is(T == uint)) return cast(T)m_inputData.get!int();
 		else static if (is(T : int)) {
-			if(m_inputData.type == Bson.Type.long_) return cast(T)m_inputData.get!long();
+			if(m_inputData.type == Bson.Type.long_) {
+				enforce((m_inputData.get!long() >= int.min) && (m_inputData.get!long() <= int.max), "Long out of range while attempting to deserialize to int: " ~ m_inputData.get!long.to!string);
+				return cast(T)m_inputData.get!long();
+			}
 			else return m_inputData.get!int().to!T;
 		}
 		else static if (is(T : long)) {


### PR DESCRIPTION
Adds the ability to deserialize a Bson long into a native int. This could be problematic for numbers outside the range of int but it should probably be checked by the developer if they are taking Bson input. This caused quite a headache when we have data coming from a Json api and wanted to merge with the Bson from MongoDB before deserializing.

This code previously did not work:

``` D
    int dest;

    auto jsonSource = Json(2048); // Imagine this came from a web request
    assert(jsonSource.type == Json.Type.int_); // The Json type is int

    auto source = Bson.fromJson(jsonSource); // We could do this so we can merge with a Bson object loaded from the database
    assert(source.type == Bson.Type.long_); // The Bson object now has a long

    dest.deserializeBson(source); // This caused an error as it was conversion from long to int

```
