### PR TITLE
Add missing import for isPublicMember

### DIFF
--- a/source/vibe/internal/meta/traits.d
+++ b/source/vibe/internal/meta/traits.d
@@ -236,6 +236,7 @@ package T Tgen(T)(){ return T.init; }
 template isPublicMember(T, string M)
 {
 	import std.algorithm;
+	import std.typetuple;
 
 	static if (!__traits(compiles, TypeTuple!(__traits(getMember, T, M)))) enum isPublicMember = false;
 	else {


### PR DESCRIPTION
`isPublicMember` doesn't work on DMD2.067 alpha because of this.
