### PR TITLE
Add HTTPClientResponse.switchProtocol()

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -20,6 +20,7 @@ import vibe.inet.url;
 import vibe.stream.counting;
 import vibe.stream.ssl;
 import vibe.stream.operations;
+import vibe.stream.wrapper : ConnectionProxyStream;
 import vibe.stream.zlib;
 import vibe.utils.array;
 import vibe.utils.memory;
@@ -881,6 +882,26 @@ final class HTTPClientResponse : HTTPResponse {
 	void disconnect()
 	{
 		finalize(true);
+	}
+
+	/**
+		Switches the connection to a new protocol and returns the resulting ConnectionStream.
+
+		The caller caller gets ownership of the ConnectionStream and is responsible
+		for closing it.
+		Params:
+			newProtocol = The protocol to which the connection is expected to upgrade. Should match the Upgrade header of the request.
+	*/
+	ConnectionStream switchProtocol(in string newProtocol)
+	{
+		enforce(statusCode == HTTPStatus.switchingProtocols, "Server did not send a 101 - Switching Protocols response");
+		string *resNewProto = "Upgrade" in headers;
+		enforce(resNewProto, "Server did not send an Upgrade header");
+		enforce(*resNewProto == newProtocol, "Expected Upgrade: " ~ newProtocol ~", received Upgrade: " ~ *resNewProto);
+		auto stream = new ConnectionProxyStream(m_client.m_stream, m_client.m_conn);
+		m_client.m_responding = false;
+		m_client = null;
+		return stream;
 	}
 
 	private void finalize()


### PR DESCRIPTION
Replaces rejectedsoftware/vibe.d#929 which I accidentally opened on my master branch.

Since the response does not have access to the request headers,
the expected protocol must be supplied as a parameter.

This is needed, for instance, to create client-side websockets.