### PR TITLE
Add doHandleWebsocket function

### DIFF
--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -64,55 +64,63 @@ class WebSocketException: Exception
 }
 
 /**
+    Establishes a web socket conection and passes it to the $(D on_handshake) delegate.
+*/
+void doHandleWebsocket(WebSocketHandshakeDelegate on_handshake, HTTPServerRequest req, HTTPServerResponse res)
+{
+	auto pUpgrade = "Upgrade" in req.headers;
+	auto pConnection = "Connection" in req.headers;
+	auto pKey = "Sec-WebSocket-Key" in req.headers;
+	//auto pProtocol = "Sec-WebSocket-Protocol" in req.headers;
+	auto pVersion = "Sec-WebSocket-Version" in req.headers;
+	
+	auto isUpgrade = false;
+	
+	if( pConnection ) {
+		auto connectionTypes = split(*pConnection, ",");
+		foreach( t ; connectionTypes ) {
+			if( t.strip().toLower() == "upgrade" ) {
+				isUpgrade = true;
+				break;
+			}
+		}
+	}
+	if( !(isUpgrade &&
+	      pUpgrade && icmp(*pUpgrade, "websocket") == 0 &&
+	      pKey &&
+	      pVersion && *pVersion == "13") )
+	{
+		logDebug("Browser sent invalid WebSocket request.");
+		res.statusCode = HTTPStatus.badRequest;
+		res.writeVoidBody();
+		return;
+	}
+
+	auto accept = cast(string)Base64.encode(sha1Of(*pKey ~ s_webSocketGuid));
+	res.headers["Sec-WebSocket-Accept"] = accept;
+	res.headers["Connection"] = "Upgrade";
+	ConnectionStream conn = res.switchProtocol("websocket");
+
+	scope socket = new WebSocket(conn, req);
+	try on_handshake(socket);
+	catch (Exception e) {
+		logDiagnostic("WebSocket handler failed: %s", e.msg);
+	} catch (Throwable th) {
+		// pretend to have sent a closing frame so that any further sends will fail
+		socket.m_sentCloseFrame = true;
+		throw th;
+	}
+	socket.close();
+}
+
+/**
 	Returns a HTTP request handler that establishes web socket conections.
 */
 HTTPServerRequestDelegate handleWebSockets(WebSocketHandshakeDelegate on_handshake)
 {
 	void callback(HTTPServerRequest req, HTTPServerResponse res)
 	{
-		auto pUpgrade = "Upgrade" in req.headers;
-		auto pConnection = "Connection" in req.headers;
-		auto pKey = "Sec-WebSocket-Key" in req.headers;
-		//auto pProtocol = "Sec-WebSocket-Protocol" in req.headers;
-		auto pVersion = "Sec-WebSocket-Version" in req.headers;
-
-		auto isUpgrade = false;
-
-		if( pConnection ) {
-			auto connectionTypes = split(*pConnection, ",");
-			foreach( t ; connectionTypes ) {
-				if( t.strip().toLower() == "upgrade" ) {
-					isUpgrade = true;
-					break;
-				}
-			}
-		}
-		if( !(isUpgrade &&
-			  pUpgrade && icmp(*pUpgrade, "websocket") == 0 &&
-			  pKey &&
-			  pVersion && *pVersion == "13") )
-		{
-			logDebug("Browser sent invalid WebSocket request.");
-			res.statusCode = HTTPStatus.badRequest;
-			res.writeVoidBody();
-			return;
-		}
-
-		auto accept = cast(string)Base64.encode(sha1Of(*pKey ~ s_webSocketGuid));
-		res.headers["Sec-WebSocket-Accept"] = accept;
-		res.headers["Connection"] = "Upgrade";
-		ConnectionStream conn = res.switchProtocol("websocket");
-
-		scope socket = new WebSocket(conn, req);
-		try on_handshake(socket);
-		catch (Exception e) {
-			logDiagnostic("WebSocket handler failed: %s", e.msg);
-		} catch (Throwable th) {
-			// pretend to have sent a closing frame so that any further sends will fail
-			socket.m_sentCloseFrame = true;
-			throw th;
-		}
-		socket.close();
+		doHandleWebsocket(on_handshake, req, res);
 	}
 	return &callback;
 }


### PR DESCRIPTION
This allows establishing a websocket connection directly in an
HTTPServerRequestDelegate, which is useful if one needs to make some
checks on the request (and possibly send an http response with an error
code) before opening the websocket.

Signed-off-by: Luca Niccoli <l.niccoli@awtech.it>