### PR TITLE
Add access to SSL peer certificate

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -598,12 +598,12 @@ final class HTTPServerRequest : HTTPRequest {
 		/// Determines if the request was issued over an SSL encrypted channel.
 		bool ssl;
 
-        /** Information about the SSL certificate provided by the client.
+		/** Information about the SSL certificate provided by the client.
 
-            Remarks: This field is only set if ssl is true, and the peer
-            presented a client certificate.
-        */
-        SSLCertificateInformation clientCertificate;
+			Remarks: This field is only set if ssl is true, and the peer
+			presented a client certificate.
+		*/
+		SSLCertificateInformation clientCertificate;
 
 		/** The _path part of the URL.
 
@@ -1358,7 +1358,7 @@ private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTT
 	// Create the response object
 	auto res = FreeListRef!HTTPServerResponse(http_stream, tcp_connection, settings, request_allocator/*.Scoped_payload*/);
 	req.ssl = res.m_ssl = listen_info.sslContext !is null;
-    if (req.ssl) req.clientCertificate = (cast(SSLStream)http_stream).peerCertificate;
+	if (req.ssl) req.clientCertificate = (cast(SSLStream)http_stream).peerCertificate;
 
 	// Error page handler
 	void errorOut(int code, string msg, string debug_msg, Throwable ex){

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -598,6 +598,13 @@ final class HTTPServerRequest : HTTPRequest {
 		/// Determines if the request was issued over an SSL encrypted channel.
 		bool ssl;
 
+        /** Information about the SSL certificate provided by the client.
+
+            Remarks: This field is only set if ssl is true, and the peer
+            presented a client certificate.
+        */
+        SSLCertificateInformation clientCertificate;
+
 		/** The _path part of the URL.
 
 			Remarks: This field is only set if HTTPServerOption.parseURL is set.
@@ -1351,6 +1358,7 @@ private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTT
 	// Create the response object
 	auto res = FreeListRef!HTTPServerResponse(http_stream, tcp_connection, settings, request_allocator/*.Scoped_payload*/);
 	req.ssl = res.m_ssl = listen_info.sslContext !is null;
+    if (req.ssl) req.clientCertificate = (cast(SSLStream)http_stream).peerCertificate;
 
 	// Error page handler
 	void errorOut(int code, string msg, string debug_msg, Throwable ex){

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -158,10 +158,10 @@ final class OpenSSLStream : SSLStream {
             ASN1_OBJECT *obj = X509_NAME_ENTRY_get_object(e);
             ASN1_STRING *val = X509_NAME_ENTRY_get_data(e);
 
-            auto longName = fromStringz(OBJ_nid2ln(OBJ_obj2nid(obj)));
+            auto longName = OBJ_nid2ln(OBJ_obj2nid(obj)).to!string;
             auto valStr = cast(string)val.data[0 .. val.length];
 
-            m_peerCertificate.subjectName[longName] = valStr;
+            m_peerCertificate.subjectName.addField(longName, valStr);
         }
     }
 

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -58,6 +58,7 @@ final class OpenSSLStream : SSLStream {
 		BIO* m_bio;
 		ubyte[64] m_peekBuffer;
 		Exception[] m_exceptions;
+        SSLCertificateInformation m_peerCertificate;
 	}
 
 	this(Stream underlying, OpenSSLContext ctx, SSLStreamState state, string peer_name = null, NetworkAddress peer_address = NetworkAddress.init)
@@ -108,6 +109,8 @@ final class OpenSSLStream : SSLStream {
 
 			if (auto peer = SSL_get_peer_certificate(m_ssl)) {
 				scope(exit) X509_free(peer);
+
+                readPeerCertInfo(peer);
 				auto result = SSL_get_verify_result(m_ssl);
 				if (result == X509_V_OK && (ctx.peerValidationMode & SSLPeerValidationMode.checkPeer)) {
 					if (!verifyCertName(peer, GENERAL_NAME.GEN_DNS, vdata.peerName)) {
@@ -142,6 +145,25 @@ final class OpenSSLStream : SSLStream {
 
 		checkExceptions();
 	}
+
+    /** Read certificate info into the clientInformation field */
+    private void readPeerCertInfo(X509 *cert)
+    {
+        X509_NAME* name = X509_get_subject_name(cert);
+
+        int c = X509_NAME_entry_count(name);
+        for (int i = 0; i < c; i++) {
+            X509_NAME_ENTRY *e = X509_NAME_get_entry(name, i);
+
+            ASN1_OBJECT *obj = X509_NAME_ENTRY_get_object(e);
+            ASN1_STRING *val = X509_NAME_ENTRY_get_data(e);
+
+            auto longName = fromStringz(OBJ_nid2ln(OBJ_obj2nid(obj)));
+            auto valStr = cast(string)val.data[0 .. val.length];
+
+            m_peerCertificate.subjectName[longName] = valStr;
+        }
+    }
 
 	~this()
 	{
@@ -266,6 +288,11 @@ final class OpenSSLStream : SSLStream {
 			throw m_exceptions[0];
 		}
 	}
+
+    @property SSLCertificateInformation peerCertificate()
+    {
+        return m_peerCertificate;
+    }
 }
 
 

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -58,7 +58,7 @@ final class OpenSSLStream : SSLStream {
 		BIO* m_bio;
 		ubyte[64] m_peekBuffer;
 		Exception[] m_exceptions;
-        SSLCertificateInformation m_peerCertificate;
+		SSLCertificateInformation m_peerCertificate;
 	}
 
 	this(Stream underlying, OpenSSLContext ctx, SSLStreamState state, string peer_name = null, NetworkAddress peer_address = NetworkAddress.init)
@@ -110,7 +110,7 @@ final class OpenSSLStream : SSLStream {
 			if (auto peer = SSL_get_peer_certificate(m_ssl)) {
 				scope(exit) X509_free(peer);
 
-                readPeerCertInfo(peer);
+				readPeerCertInfo(peer);
 				auto result = SSL_get_verify_result(m_ssl);
 				if (result == X509_V_OK && (ctx.peerValidationMode & SSLPeerValidationMode.checkPeer)) {
 					if (!verifyCertName(peer, GENERAL_NAME.GEN_DNS, vdata.peerName)) {
@@ -146,24 +146,24 @@ final class OpenSSLStream : SSLStream {
 		checkExceptions();
 	}
 
-    /** Read certificate info into the clientInformation field */
-    private void readPeerCertInfo(X509 *cert)
-    {
-        X509_NAME* name = X509_get_subject_name(cert);
+	/** Read certificate info into the clientInformation field */
+	private void readPeerCertInfo(X509 *cert)
+	{
+		X509_NAME* name = X509_get_subject_name(cert);
 
-        int c = X509_NAME_entry_count(name);
-        for (int i = 0; i < c; i++) {
-            X509_NAME_ENTRY *e = X509_NAME_get_entry(name, i);
+		int c = X509_NAME_entry_count(name);
+		foreach (i; 0 .. c) {
+			X509_NAME_ENTRY *e = X509_NAME_get_entry(name, i);
 
-            ASN1_OBJECT *obj = X509_NAME_ENTRY_get_object(e);
-            ASN1_STRING *val = X509_NAME_ENTRY_get_data(e);
+			ASN1_OBJECT *obj = X509_NAME_ENTRY_get_object(e);
+			ASN1_STRING *val = X509_NAME_ENTRY_get_data(e);
 
-            auto longName = OBJ_nid2ln(OBJ_obj2nid(obj)).to!string;
-            auto valStr = cast(string)val.data[0 .. val.length];
+			auto longName = OBJ_nid2ln(OBJ_obj2nid(obj)).to!string;
+			auto valStr = cast(string)val.data[0 .. val.length];
 
-            m_peerCertificate.subjectName.addField(longName, valStr);
-        }
-    }
+			m_peerCertificate.subjectName.addField(longName, valStr);
+		}
+	}
 
 	~this()
 	{
@@ -289,10 +289,10 @@ final class OpenSSLStream : SSLStream {
 		}
 	}
 
-    @property SSLCertificateInformation peerCertificate()
-    {
-        return m_peerCertificate;
-    }
+	@property SSLCertificateInformation peerCertificate()
+	{
+		return m_peerCertificate;
+	}
 }
 
 

--- a/source/vibe/stream/ssl.d
+++ b/source/vibe/stream/ssl.d
@@ -16,6 +16,8 @@ import vibe.core.net;
 import vibe.core.stream;
 import vibe.core.sync;
 
+import vibe.utils.dictionarylist;
+
 import std.algorithm;
 import std.array;
 import std.conv;
@@ -379,7 +381,7 @@ struct SSLCertificateInformation {
         Maps fields to their values. For example, typical fields on a
         certificate will be 'commonName', 'countryName', 'emailAddress', etc.
     */
-    string[string] subjectName;
+    DictionaryList!(string, false) subjectName;
 }
 
 struct SSLPeerValidationData {

--- a/source/vibe/stream/ssl.d
+++ b/source/vibe/stream/ssl.d
@@ -164,7 +164,7 @@ void setSSLContextFactory(SSLContext function(SSLContextKind, SSLVersion) factor
 		tunnel is properly closed first.
 */
 interface SSLStream : Stream {
-    @property SSLCertificateInformation peerCertificate();
+	@property SSLCertificateInformation peerCertificate();
 }
 
 enum SSLStreamState {
@@ -370,18 +370,18 @@ enum SSLPeerValidationMode {
 
 		See_also: $(D useTrustedCertificateFile)
 	*/
-    trustedCert = validCert | checkTrust,
+	trustedCert = validCert | checkTrust,
 }
 
 /** Certificate information  */
 struct SSLCertificateInformation {
 
-    /** Information about the certificate's subject name.
+	/** Information about the certificate's subject name.
 
-        Maps fields to their values. For example, typical fields on a
-        certificate will be 'commonName', 'countryName', 'emailAddress', etc.
-    */
-    DictionaryList!(string, false) subjectName;
+		Maps fields to their values. For example, typical fields on a
+		certificate will be 'commonName', 'countryName', 'emailAddress', etc.
+	*/
+	DictionaryList!(string, false) subjectName;
 }
 
 struct SSLPeerValidationData {

--- a/source/vibe/stream/ssl.d
+++ b/source/vibe/stream/ssl.d
@@ -162,6 +162,7 @@ void setSSLContextFactory(SSLContext function(SSLContextKind, SSLVersion) factor
 		tunnel is properly closed first.
 */
 interface SSLStream : Stream {
+    @property SSLCertificateInformation peerCertificate();
 }
 
 enum SSLStreamState {
@@ -368,6 +369,17 @@ enum SSLPeerValidationMode {
 		See_also: $(D useTrustedCertificateFile)
 	*/
     trustedCert = validCert | checkTrust,
+}
+
+/** Certificate information  */
+struct SSLCertificateInformation {
+
+    /** Information about the certificate's subject name.
+
+        Maps fields to their values. For example, typical fields on a
+        certificate will be 'commonName', 'countryName', 'emailAddress', etc.
+    */
+    string[string] subjectName;
 }
 
 struct SSLPeerValidationData {


### PR DESCRIPTION
Provide access to a client's certificate information, which makes client
cert based auth/cert SSO a lot more useful.