### PR TITLE
REST enhancement #1.2: Implementation of @queryParam & @bodyParam

### DIFF
--- a/source/vibe/web/common.d
+++ b/source/vibe/web/common.d
@@ -513,37 +513,35 @@ version (none) {
  * void login(string auth);
  * ----
  */
-WebParamAttribute headerParam(string identifier, string field) {
+WebParamAttribute headerParam(string identifier, string field)
+{
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(WebParamAttribute.Origin.Header, identifier, field);
 }
 
-version (none) {
-	// It's not yet implemented in the REST and web interface.
-	/*
-	 * Declare that a parameter will be transmitted to the API through the query string.
-	 *
-	 * It will be serialized as part of a JSON object, and will go through URL serialization.
-	 * The serialization format is not customizable.
-	 *
-	 * Params:
-	 * - identifier: The name of the parameter to customize. A compiler error will be issued on mismatch.
-	 * - field: The field name to use.
-	 *
-	 * ----
-	 * // For a call to postData("D is awesome"), the server will receive the query:
-	 * // POST /data?test=%22D is awesome%22
-	 * @queryParam("data", "test")
-	 * void postData(string data);
-	 * ----
-	 */
-	private WebParamAttribute queryParam(string identifier, string field) {
-
-		if (!__ctfe)
-			assert(false, onlyAsUda!__FUNCTION__);
-		return WebParamAttribute(WebParamAttribute.Origin.Query, identifier, field);
-	}
+/**
+ * Declare that a parameter will be transmitted to the API through the query string.
+ *
+ * It will be serialized as part of a JSON object, and will go through URL serialization.
+ * The serialization format is not customizable.
+ *
+ * Params:
+ * - identifier: The name of the parameter to customize. A compiler error will be issued on mismatch.
+ * - field: The field name to use.
+ *
+ * ----
+ * // For a call to postData("D is awesome"), the server will receive the query:
+ * // POST /data?test=%22D is awesome%22
+ * @queryParam("data", "test")
+ * void postData(string data);
+ * ----
+ */
+WebParamAttribute queryParam(string identifier, string field)
+{
+	if (!__ctfe)
+		assert(false, onlyAsUda!__FUNCTION__);
+	return WebParamAttribute(WebParamAttribute.Origin.Query, identifier, field);
 }
 
 /**

--- a/source/vibe/web/common.d
+++ b/source/vibe/web/common.d
@@ -470,30 +470,27 @@ package struct WebParamAttribute {
 	string field;
 }
 
-version (none) {
-	// It's not yet implemented in the REST and web interface.
-	/*
-	 * Declare that a parameter will be transmitted to the API through the body.
-	 *
-	 * It will be serialized as part of a JSON object.
-	 * The serialization format is currently not customizable.
-	 *
-	 * Params:
-	 * - identifier: The name of the parameter to customize. A compiler error will be issued on mismatch.
-	 * - field: The name of the field in the JSON object.
-	 *
-	 * ----
-	 * @bodyParam("pack", "package")
-	 * void ship(int pack);
-	 * // The server will receive the following body for a call to ship(42):
-	 * // { "package": 42 }
-	 * ----
-	 */
-	private WebParamAttribute bodyParam(string identifier, string field) {
-		if (!__ctfe)
-			assert(false, onlyAsUda!__FUNCTION__);
-		return WebParamAttribute(WebParamAttribute.Origin.Body, identifier, field);
-	}
+/**
+ * Declare that a parameter will be transmitted to the API through the body.
+ *
+ * It will be serialized as part of a JSON object.
+ * The serialization format is currently not customizable.
+ *
+ * Params:
+ * - identifier: The name of the parameter to customize. A compiler error will be issued on mismatch.
+ * - field: The name of the field in the JSON object.
+ *
+ * ----
+ * @bodyParam("pack", "package")
+ * void ship(int pack);
+ * // The server will receive the following body for a call to ship(42):
+ * // { "package": 42 }
+ * ----
+ */
+WebParamAttribute bodyParam(string identifier, string field) {
+	if (!__ctfe)
+		assert(false, onlyAsUda!__FUNCTION__);
+	return WebParamAttribute(WebParamAttribute.Origin.Body, identifier, field);
 }
 
 /**

--- a/source/vibe/web/rest.d
+++ b/source/vibe/web/rest.d
@@ -979,8 +979,10 @@ private string genClientBody(alias Func)() {
 				static assert (paramsArgList.length == 1, "Multiple attribute for parameter '"~ParamNames[i]~"' in "~FuncId);
 				static if (paramsArgList[0].origin == WebParamAttribute.Origin.Header)
 					param_handling_str ~= format(q{headers__["%s"] = to!string(%s);}, paramsArgList[0].field, paramsArgList[0].identifier);
+				else static if (paramsArgList[0].origin == WebParamAttribute.Origin.Query)
+					queryParamCTMap[paramsArgList[0].field] = paramsArgList[0].identifier;
 				else
-					static assert (0, "Only header parameter are currently supported client-side");
+					static assert (0, "Internal error: Unknown WebParamAttribute.Origin in REST client code generation.");
 			} else static if (!ParamNames[i].startsWith("_")
 					  && !IsAttributedParameter!(Func, ParamNames[i])) {
 				// underscore parameters are sourced from the HTTPServerRequest.params map or from url itself


### PR DESCRIPTION
Okay, this had been stalling in my computer for a while now, time to push it.
Those are the complements of `@headerParam`. Since most of the work had been done in #926 , this is pretty straightforward.
