### PR TITLE
Get rid of missing SSL context errors

### DIFF
--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -322,7 +322,7 @@ final class OpenSSLContext : SSLContext {
 		if (kind == SSLContextKind.server) {
 			setDHParams();
 			static if (haveECDH) setECDHCurve();
-			setContextID();
+			guessSessionIDContext();
 		}
 
 		setCipherList();
@@ -473,10 +473,14 @@ final class OpenSSLContext : SSLContext {
 
 	/** Make up a context ID to assign to the SSL context.
 
-		This is very required when doing client cert authentication,
-		otherwise many connections will go aborted.
+		This is required when doing client cert authentication, otherwise many
+		connections will go aborted as the client tries to revive a session
+		that it used to have on another machine.
+
+		The session ID context should be unique within a pool of servers.
+		Currently, this is achieved by taking the hostname.
 	*/
-	void setContextID()
+	private void guessSessionIDContext()
 	{
 		string contextID = Socket.hostName;
 		SSL_CTX_set_session_id_context(m_ctx, cast(ubyte*)contextID.toStringz(), cast(uint)contextID.length);

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -322,7 +322,7 @@ final class OpenSSLContext : SSLContext {
 		if (kind == SSLContextKind.server) {
 			setDHParams();
 			static if (haveECDH) setECDHCurve();
-	        setContextID();
+			setContextID();
 		}
 
 		setCipherList();

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -322,7 +322,7 @@ final class OpenSSLContext : SSLContext {
 		if (kind == SSLContextKind.server) {
 			setDHParams();
 			static if (haveECDH) setECDHCurve();
-            setContextID();
+	        setContextID();
 		}
 
 		setCipherList();
@@ -471,16 +471,16 @@ final class OpenSSLContext : SSLContext {
 			SSL_CTX_set_cipher_list(m_ctx, toStringz(list));
 	}
 
-    /** Make up a context ID to assign to the SSL context.
+	/** Make up a context ID to assign to the SSL context.
 
-        This is very required when doing client cert authentication,
-        otherwise many connections will go aborted.
-    */
-    void setContextID()
-    {
-        string contextID = Socket.hostName;
-        SSL_CTX_set_session_id_context(m_ctx, cast(ubyte*)contextID.toStringz(), cast(uint)contextID.length);
-    }
+		This is very required when doing client cert authentication,
+		otherwise many connections will go aborted.
+	*/
+	void setContextID()
+	{
+		string contextID = Socket.hostName;
+		SSL_CTX_set_session_id_context(m_ctx, cast(ubyte*)contextID.toStringz(), cast(uint)contextID.length);
+	}
 
 	/** Set params to use for DH cipher.
 	 *

--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -17,6 +17,7 @@ import std.algorithm;
 import std.array;
 import std.conv;
 import std.exception;
+import std.socket;
 import std.string;
 
 import core.stdc.string : strlen;
@@ -321,6 +322,7 @@ final class OpenSSLContext : SSLContext {
 		if (kind == SSLContextKind.server) {
 			setDHParams();
 			static if (haveECDH) setECDHCurve();
+            setContextID();
 		}
 
 		setCipherList();
@@ -468,6 +470,17 @@ final class OpenSSLContext : SSLContext {
 		else
 			SSL_CTX_set_cipher_list(m_ctx, toStringz(list));
 	}
+
+    /** Make up a context ID to assign to the SSL context.
+
+        This is very required when doing client cert authentication,
+        otherwise many connections will go aborted.
+    */
+    void setContextID()
+    {
+        string contextID = Socket.hostName;
+        SSL_CTX_set_session_id_context(m_ctx, cast(ubyte*)contextID.toStringz(), cast(uint)contextID.length);
+    }
 
 	/** Set params to use for DH cipher.
 	 *


### PR DESCRIPTION
This occurs a lot when using client cetificates, and then connections
are dropped a couple of times before they are succesfully estbalished:

    [0B573E01:0B613C01 2015.01.28 17:11:07.064 WRN] Handling of
    connection failed: Failed to accept SSL tunnel: error:140D9115:SSL
    routines:SSL_GET_PREV_SESSION:session id context uninitialized
    (336433429)

Assigning the local hostname as a context ID fixes this error.

As per OpenSSL documentation:

https://www.openssl.org/docs/ssl/SSL_CTX_set_session_id_context.html