### PR TITLE
Get Vibe.d ready for 2.067

### DIFF
--- a/source/vibe/core/concurrency.d
+++ b/source/vibe/core/concurrency.d
@@ -320,7 +320,7 @@ template Isolated(T)
 
 
 // unit tests fails with DMD 2.064 due to some cyclic import regression
-version (none) unittest
+unittest
 {
 	static class CE {}
 	static struct SE {}

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -29,6 +29,7 @@ import core.sync.mutex;
 import core.stdc.stdlib;
 import core.thread;
 
+alias TaskEventCb = void function(TaskEvent, Task) nothrow;
 
 version(Posix)
 {
@@ -677,7 +678,7 @@ void lowerPrivileges()
 	analyze the life time of tasks, including task switches. Note that
 	the callback will only be called for debug builds.
 */
-void setTaskEventCallback(void function(TaskEvent, Task) func)
+void setTaskEventCallback(TaskEventCb func)
 {
 	debug s_taskEventCallback = func;
 }
@@ -1210,7 +1211,7 @@ private {
 	__gshared ThreadContext[] st_threads;
 	__gshared TaskFuncInfo[] st_workerTasks;
 	__gshared Condition st_threadShutdownCondition;
-	__gshared debug void function(TaskEvent, Task) s_taskEventCallback;
+	__gshared debug TaskEventCb s_taskEventCallback;
 	shared bool st_term = false;
 
 	bool s_exitEventLoop = false;

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1095,7 +1095,10 @@ private class VibeDriverCore : DriverCore {
 			ctask.m_exception = event_exception;
 		}
 
-		auto uncaught_exception = ctask.call(false);
+		static if (__VERSION__ > 2067)
+			auto uncaught_exception = ctask.call!(Fiber.Rethrow.no)();
+		else
+			auto uncaught_exception = ctask.call(false);
 		if (auto th = cast(Throwable)uncaught_exception) {
 			extrap();
 			assert(ctask.state == Fiber.State.TERM);

--- a/source/vibe/core/driver.d
+++ b/source/vibe/core/driver.d
@@ -165,7 +165,7 @@ interface EventDriver {
 interface DriverCore {
 	@property void eventException(Exception e);
 	void yieldForEvent();
-	void resumeTask(Task f, Exception event_exception = null);
+	void resumeTask(Task f, Exception event_exception = null) nothrow;
 	void notifyIdle();
 }
 

--- a/source/vibe/core/driver.d
+++ b/source/vibe/core/driver.d
@@ -28,14 +28,14 @@ version (VibeUseNativeDriverType) {
 /**
 	Returns the active event driver
 */
-StoredEventDriver getEventDriver(bool ignore_unloaded = false)
+StoredEventDriver getEventDriver(bool ignore_unloaded = false) nothrow
 {
 	assert(ignore_unloaded || s_driver !is null, "No event driver loaded. Did the vibe.core.core module constructor run?");
 	return s_driver;
 }
 
 /// private
-package void setupEventDriver(DriverCore core_)
+package void setupEventDriver(DriverCore core_) nothrow
 {
 	version (VibeUseNativeDriverType) {}
 	else import vibe.core.drivers.native;

--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -79,15 +79,15 @@ final class Libevent2Driver : EventDriver {
 
 	this(DriverCore core) nothrow
 	{
-		debug m_ownerThread = Thread.getThis();
-		m_core = core;
-		s_driverCore = core;
-
 		// In 2067, synchronized statements where annotated nothrow.
 		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
 		// However, they were "logically" nothrow before.
 		static if (__VERSION__ <= 2066)
 			scope (failure) assert(0, "Internal error: function should be nothrow");
+
+		debug m_ownerThread = Thread.getThis();
+		m_core = core;
+		s_driverCore = core;
 
 		synchronized if (!s_threadObjectsMutex) {
 			s_threadObjectsMutex = new Mutex;
@@ -676,14 +676,14 @@ final class Libevent2ManualEvent : Libevent2Object, ManualEvent {
 
 	void acquire() nothrow
 	{
-		auto task = Task.getThis();
-		auto thread = task == Task() ? Thread.getThis() : task.thread;
-
 		// In 2067, synchronized statements where annotated nothrow.
 		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
 		// However, they were "logically" nothrow before.
 		static if (__VERSION__ <= 2066)
 			scope (failure) assert(0, "Internal error: function should be nothrow");
+
+		auto task = Task.getThis();
+		auto thread = task == Task() ? Thread.getThis() : task.thread;
 
 		synchronized (m_mutex) {
 			if (thread !in m_waiters) {

--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -577,7 +577,7 @@ private class Libevent2Object {
 		m_driver.unregisterObject(this);
 	}
 
-	protected void onThreadShutdown() {}
+	protected void onThreadShutdown() nothrow {}
 }
 
 /// private
@@ -668,10 +668,16 @@ final class Libevent2ManualEvent : Libevent2Object, ManualEvent {
 		return ec;
 	}
 
-	void acquire()
+	void acquire() nothrow
 	{
 		auto task = Task.getThis();
 		auto thread = task == Task() ? Thread.getThis() : task.thread;
+
+		// In 2067, synchronized statements where annotated nothrow.
+		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+		// However, they were "logically" nothrow before.
+		static if (__VERSION__ <= 2066)
+			scope (failure) assert(0, "Internal error: function should be nothrow");
 
 		synchronized (m_mutex) {
 			if (thread !in m_waiters) {
@@ -701,8 +707,14 @@ final class Libevent2ManualEvent : Libevent2Object, ManualEvent {
 		}
 	}
 
-	bool amOwner()
+	bool amOwner() nothrow
 	{
+		// In 2067, synchronized statements where annotated nothrow.
+		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+		// However, they were "logically" nothrow before.
+		static if (__VERSION__ <= 2066)
+			scope (failure) assert(0, "Internal error: function should be nothrow");
+
 		auto self = Task.getThis();
 		if (self == Task()) return false;
 		synchronized (m_mutex) {
@@ -715,6 +727,12 @@ final class Libevent2ManualEvent : Libevent2Object, ManualEvent {
 
 	protected override void onThreadShutdown()
 	{
+		// In 2067, synchronized statements where annotated nothrow.
+		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+		// However, they were "logically" nothrow before.
+		static if (__VERSION__ <= 2066)
+			scope (failure) assert(0, "Internal error: function should be nothrow");
+
 		auto thr = Thread.getThis();
 		synchronized (m_mutex) {
 			if (thr in m_waiters) {

--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -611,6 +611,12 @@ final class Libevent2ManualEvent : Libevent2Object, ManualEvent {
 
 	void emit()
 	{
+		// In 2067, synchronized statements where annotated nothrow.
+		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+		// However, they were "logically" nothrow before.
+		static if (__VERSION__ <= 2066)
+			scope (failure) assert(0, "Internal error: function should be nothrow");
+
 		atomicOp!"+="(m_emitCount, 1);
 		synchronized (m_mutex) {
 			foreach (ref sl; m_waiters)

--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -171,8 +171,8 @@ final class Libevent2Driver : EventDriver {
 		s_alreadyDeinitialized = true;
 	}
 
-	@property event_base* eventLoop() { return m_eventLoop; }
-	@property evdns_base* dnsEngine() { return m_dnsBase; }
+	@property event_base* eventLoop() nothrow { return m_eventLoop; }
+	@property evdns_base* dnsEngine() nothrow { return m_dnsBase; }
 
 	int runEventLoop()
 	{

--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -13,8 +13,11 @@ public import vibe.inet.url;
 import vibe.core.drivers.threadedfile; // temporarily needed tp get mkstemps to work
 import vibe.core.driver;
 
-import std.conv;
-import std.c.stdio;
+static if (__VERSION__ > 2066)
+	import core.stdc.stdio;
+else
+	import std.c.stdio;
+
 import std.datetime;
 import std.exception;
 import std.file;
@@ -136,6 +139,7 @@ void writeFileUTF8(Path path, string contents)
 FileStream createTempFile(string suffix = null)
 {
 	version(Windows){
+		import std.conv : to;
 		char[L_tmpnam] tmp;
 		tmpnam(tmp.ptr);
 		auto tmpname = to!string(tmp.ptr);

--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -214,19 +214,24 @@ void removeFile(Path path)
 	removeFile(path.toNativeString());
 }
 /// ditto
-void removeFile(string path) {
+void removeFile(string path)
+{
 	std.file.remove(path);
 }
 
 /**
 	Checks if a file exists
 */
-bool existsFile(Path path) {
+bool existsFile(Path path) nothrow
+{
 	return existsFile(path.toNativeString());
 }
 /// ditto
-bool existsFile(string path)
+bool existsFile(string path) nothrow
 {
+	// This was *annotated* nothrow in 2.067.
+	static if (__VERSION__ < 2067)
+		scope(failure) assert(0, "Error: existsFile should never throw");
 	return std.file.exists(path);
 }
 

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -166,6 +166,7 @@ struct NetworkAddress {
 		import std.array : appender;
 		import std.string : format;
 		import std.format : formattedWrite;
+		ubyte[2] _dummy = void; // Workaround for DMD regression in master
 
 		switch (this.family) {
 			default: assert(false, "toAddressString() called for invalid address family.");
@@ -178,7 +179,8 @@ struct NetworkAddress {
 				ret.reserve(40);
 				foreach (i; 0 .. 8) {
 					if (i > 0) ret.put(':');
-					ret.formattedWrite("%x", bigEndianToNative!ushort(cast(ubyte[2])ip[i*2 .. i*2+2]));
+					_dummy[] = ip[i*2 .. i*2+2];
+					ret.formattedWrite("%x", bigEndianToNative!ushort(_dummy));
 				}
 				return ret.data;
 		}

--- a/source/vibe/core/task.d
+++ b/source/vibe/core/task.d
@@ -34,18 +34,24 @@ struct Task {
 		}
 	}
 
-	private this(TaskFiber fiber, size_t task_counter)
+	private this(TaskFiber fiber, size_t task_counter) nothrow
 	{
 		m_fiber = cast(shared)fiber;
 		m_taskCounter = task_counter;
 	}
 
-	this(in Task other) { m_fiber = cast(shared(TaskFiber))other.m_fiber; m_taskCounter = other.m_taskCounter; }
+	this(in Task other) nothrow { m_fiber = cast(shared(TaskFiber))other.m_fiber; m_taskCounter = other.m_taskCounter; }
 
 	/** Returns the Task instance belonging to the calling task.
 	*/
-	static Task getThis()
+	static Task getThis() nothrow
 	{
+		// In 2067, synchronized statements where annotated nothrow.
+		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+		// However, they were "logically" nothrow before.
+		static if (__VERSION__ <= 2066)
+			scope (failure) assert(0, "Internal error: function should be nothrow");
+
 		auto fiber = Fiber.getThis();
 		if (!fiber) return Task.init;
 		auto tfiber = cast(TaskFiber)fiber;

--- a/source/vibe/crypto/passwordhash.d
+++ b/source/vibe/crypto/passwordhash.d
@@ -62,6 +62,7 @@ string generateSimplePasswordHash(string password, string additional_salt = null
 deprecated("This function is considered insecure and will be removed. The DUB packages dauth or scrypt may be suitable alternatives.")
 bool testSimplePasswordHash(string hashstring, string password, string additional_salt = null)
 {
+	import std.string : format;
 	ubyte[] upass = Base64.decode(hashstring);
 	enforce(upass.length == 20, format("Invalid binary password hash length: %s", upass.length));
 	auto salt = upass[0 .. 4];

--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -601,7 +601,7 @@ struct CookieValueMap {
 
 	inout(string)* opBinaryRight(string op)(string name) inout if(op == "in")
 	{
-		foreach(c; m_entries)
+		foreach(ref c; m_entries)
 			if( c.name == name )
 				return &c.value;
 		return null;

--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -601,9 +601,15 @@ struct CookieValueMap {
 
 	inout(string)* opBinaryRight(string op)(string name) inout if(op == "in")
 	{
-		foreach(ref c; m_entries)
-			if( c.name == name )
-				return &c.value;
+		static if (__VERSION__ < 2066) {
+			foreach(c; m_entries)
+				if( c.name == name )
+					return &c.value;
+		} else {
+			foreach(ref c; m_entries)
+				if( c.name == name )
+					return &c.value;
+		}
 		return null;
 	}
 }

--- a/source/vibe/inet/path.d
+++ b/source/vibe/inet/path.d
@@ -94,17 +94,17 @@ struct Path {
 	}
 	
 	/// Converts the Path object to a native path string (backslash as path separator on Windows).
-	string toNativeString()
+	string toNativeString() nothrow
 	const {
 		Appender!string ret;
 		
 		// for absolute unix paths start with /
-		version(Posix) { if(absolute) ret.put('/'); }
+		version(Posix) { if (m_absolute) ret.put('/'); }
 		
 		foreach( i, f; m_nodes ){
 			version(Windows) { if( i > 0 ) ret.put('\\'); }
 			version(Posix) { if( i > 0 ) ret.put('/'); }
-			else { enforce("Unsupported OS"); }
+			else { static assert(0, "Unsupported OS"); }
 			ret.put(f.toString());
 		}
 		
@@ -366,7 +366,7 @@ struct PathEntry {
 		m_name = str;
 	}
 	
-	string toString() const { return m_name; }
+	string toString() const nothrow { return m_name; }
 
 	Path opBinary(string OP)(PathEntry rhs) const if( OP == "~" ) { return Path(cast(immutable)[this, rhs], false); }
 	

--- a/source/vibe/internal/meta/traits.d
+++ b/source/vibe/internal/meta/traits.d
@@ -349,3 +349,24 @@ bool areConvertibleTo(alias TYPES, alias TARGET_TYPES)()
 			return false;
 	return true;
 }
+
+/// Test if the type $(D DG) is a correct delegate for an opApply where the
+/// key/index is of type $(D TKEY) and the value of type $(D TVALUE).
+template isOpApplyDg(DG, TKEY, TVALUE) {
+	import std.traits;
+	static if (is(DG == delegate) && is(ReturnType!DG : int)) {
+		private alias PTT = ParameterTypeTuple!(DG);
+		private alias PSCT = ParameterStorageClassTuple!(DG);
+		private alias STC = ParameterStorageClass;
+		// Just a value
+		static if (PTT.length == 1) {
+			enum isOpApplyDg = (is(PTT[0] == TVALUE) && PSCT[0] == STC.ref_);
+		} else static if (PTT.length == 2) {
+			enum isOpApplyDg = (is(PTT[0] == TKEY) && PSCT[0] == STC.ref_)
+				&& (is(PTT[1] == TKEY) && PSCT[1] == STC.ref_);
+		} else
+			enum isOpApplyDg = false;
+	} else {
+		enum isOpApplyDg = false;
+	}
+}

--- a/source/vibe/internal/newconcurrency.d
+++ b/source/vibe/internal/newconcurrency.d
@@ -1,7 +1,7 @@
 /// Small helper module to determine if the new std.concurrency interop features are present
 module vibe.internal.newconcurrency;
 
-static if (__VERSION__ >= 2066) {
+static if (__VERSION__ >= 2066 && false) {
 	import std.concurrency;
 	static if (is(std.concurrency.Scheduler)) enum bool newStdConcurrency = true;
 	else enum bool newStdConcurrency = false;

--- a/source/vibe/utils/hashmap.d
+++ b/source/vibe/utils/hashmap.d
@@ -81,6 +81,14 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 		return m_table[idx].value;
 	}
 
+	/// Workaround #12647
+	package Value getNothrow(Key key, Value default_value = Value.init)
+	{
+		auto idx = findIndex(key);
+		if (idx == size_t.max) return default_value;
+		return m_table[idx].value;
+	}
+
 	static if (!is(typeof({ Value v; const(Value) vc; v = vc; }))) {
 		const(Value) get(Key key, lazy const(Value) default_value = Value.init)
 		{
@@ -175,7 +183,7 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 		resize(newcap);
 	}
 
-	private void resize(size_t new_size)
+	private void resize(size_t new_size) nothrow
 	{
 		assert(!m_resizing);
 		m_resizing = true;

--- a/source/vibe/utils/hashmap.d
+++ b/source/vibe/utils/hashmap.d
@@ -34,7 +34,7 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 		TableEntry[] m_table; // NOTE: capacity is always POT
 		size_t m_length;
 		Allocator m_allocator;
-		hash_t delegate(Key) m_hasher;
+		hash_t delegate(Key) nothrow m_hasher;
 		bool m_resizing;
 	}
 
@@ -123,7 +123,7 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 		return &m_table[idx].value;
 	}
 
-	int opApply(int delegate(ref Value) nothrow del) nothrow
+	int opApply(int delegate(ref Value) del)
 	{
 		foreach (i; 0 .. m_table.length)
 			if (!Traits.equals(m_table[i].key, Traits.clearValue))
@@ -132,7 +132,7 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 		return 0;
 	}
 
-	int opApply(int delegate(in ref Key, ref Value) nothrow del) nothrow
+	int opApply(int delegate(in ref Key, ref Value) del)
 	{
 		foreach (i; 0 .. m_table.length)
 			if (!Traits.equals(m_table[i].key, Traits.clearValue))

--- a/source/vibe/utils/hashmap.d
+++ b/source/vibe/utils/hashmap.d
@@ -123,7 +123,7 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 		return &m_table[idx].value;
 	}
 
-	int opApply(int delegate(ref Value) del)
+	int opApply(int delegate(ref Value) nothrow del) nothrow
 	{
 		foreach (i; 0 .. m_table.length)
 			if (!Traits.equals(m_table[i].key, Traits.clearValue))
@@ -132,26 +132,8 @@ struct HashMap(Key, Value, Traits = DefaultHashMapTraits!Key)
 		return 0;
 	}
 
-	int opApply(int delegate(in ref Value) del)
-	const {
-		foreach (i; 0 .. m_table.length)
-			if (!Traits.equals(m_table[i].key, Traits.clearValue))
-				if (auto ret = del(m_table[i].value))
-					return ret;
-		return 0;
-	}
-
-	int opApply(int delegate(in ref Key, ref Value) del)
+	int opApply(int delegate(in ref Key, ref Value) nothrow del) nothrow
 	{
-		foreach (i; 0 .. m_table.length)
-			if (!Traits.equals(m_table[i].key, Traits.clearValue))
-				if (auto ret = del(m_table[i].key, m_table[i].value))
-					return ret;
-		return 0;
-	}
-
-	int opApply(int delegate(in ref Key, in ref Value) del)
-	const {
 		foreach (i; 0 .. m_table.length)
 			if (!Traits.equals(m_table[i].key, Traits.clearValue))
 				if (auto ret = del(m_table[i].key, m_table[i].value))

--- a/source/vibe/utils/memory.d
+++ b/source/vibe/utils/memory.d
@@ -24,8 +24,7 @@ import std.exception : enforceEx;
 import std.traits;
 import std.algorithm;
 
-
-Allocator defaultAllocator()
+Allocator defaultAllocator() nothrow
 {
 	version(VibeManualMemoryManagement){
 		return manualAllocator();
@@ -41,7 +40,7 @@ Allocator defaultAllocator()
 	}
 }
 
-Allocator manualAllocator()
+Allocator manualAllocator() nothrow
 {
 	static __gshared Allocator alloc;
 	if( !alloc ){
@@ -59,7 +58,7 @@ auto allocObject(T, bool MANAGED = true, ARGS...)(Allocator allocator, ARGS args
 	static if( MANAGED ){
 		static if( hasIndirections!T )
 			GC.addRange(mem.ptr, mem.length);
-		return emplace!T(mem, args);
+		return internalEmplace!T(mem, args);
 	}
 	else static if( is(T == class) ) return cast(T)mem.ptr;
 	else return cast(T*)mem.ptr;
@@ -74,7 +73,7 @@ T[] allocArray(T, bool MANAGED = true)(Allocator allocator, size_t n)
 			GC.addRange(mem.ptr, mem.length);
 		// TODO: use memset for class, pointers and scalars
 		foreach (ref el; ret) {
-			emplace!T(cast(void[])((&el)[0 .. 1]));
+			internalEmplace!T(cast(void[])((&el)[0 .. 1]));
 		}
 	}
 	return ret;
@@ -90,6 +89,7 @@ void freeArray(T, bool MANAGED = true)(Allocator allocator, ref T[] array)
 
 
 interface Allocator {
+nothrow:
 	enum size_t alignment = 0x10;
 	enum size_t alignmentMask = alignment-1;
 
@@ -118,20 +118,46 @@ class LockAllocator : Allocator {
 	private {
 		Allocator m_base;
 	}
-	this(Allocator base) { m_base = base; }
-	void[] alloc(size_t sz) { synchronized(this) return m_base.alloc(sz); }
+	this(Allocator base) nothrow { m_base = base; }
+	void[] alloc(size_t sz) {
+		// In 2067, synchronized statements where annotated nothrow.
+		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+		// However, they were "logically" nothrow before.
+		static if (__VERSION__ <= 2066)
+			scope (failure) assert(0, "Internal error: function should be nothrow");
+
+		synchronized(this)
+			return m_base.alloc(sz);
+	}
 	void[] realloc(void[] mem, size_t new_sz)
 		in {
 			assert(mem.ptr !is null, "realloc() called with null array.");
 			assert((cast(size_t)mem.ptr & alignmentMask) == 0, "misaligned pointer passed to realloc().");
 		}
-		body { synchronized(this) return m_base.realloc(mem, new_sz); }
+		body {
+			// In 2067, synchronized statements where annotated nothrow.
+			// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+			// However, they were "logically" nothrow before.
+			static if (__VERSION__ <= 2066)
+				scope (failure) assert(0, "Internal error: function should be nothrow");
+
+			synchronized(this)
+				return m_base.realloc(mem, new_sz);
+		}
 	void free(void[] mem)
 		in {
 			assert(mem.ptr !is null, "free() called with null array.");
 			assert((cast(size_t)mem.ptr & alignmentMask) == 0, "misaligned pointer passed to free().");
 		}
-		body { synchronized(this) m_base.free(mem); }
+		body {
+			// In 2067, synchronized statements where annotated nothrow.
+			// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
+			// However, they were "logically" nothrow before.
+			static if (__VERSION__ <= 2066)
+				scope (failure) assert(0, "Internal error: function should be nothrow");
+			synchronized(this)
+				m_base.free(mem);
+		}
 }
 
 final class DebugAllocator : Allocator {
@@ -143,7 +169,7 @@ final class DebugAllocator : Allocator {
 		size_t m_maxBytes;
 	}
 
-	this(Allocator base_allocator)
+	this(Allocator base_allocator) nothrow
 	{
 		m_baseAlloc = base_allocator;
 		m_blocks = HashMap!(void*, size_t)(manualAllocator());
@@ -157,7 +183,7 @@ final class DebugAllocator : Allocator {
 	{
 		auto ret = m_baseAlloc.alloc(sz);
 		assert(ret.length == sz, "base.alloc() returned block with wrong size.");
-		assert(m_blocks.get(ret.ptr, size_t.max) == size_t.max, "base.alloc() returned block that is already allocated.");
+		assert(m_blocks.getNothrow(ret.ptr, size_t.max) == size_t.max, "base.alloc() returned block that is already allocated.");
 		m_blocks[ret.ptr] = sz;
 		m_bytes += sz;
 		if( m_bytes > m_maxBytes ){
@@ -169,12 +195,12 @@ final class DebugAllocator : Allocator {
 
 	void[] realloc(void[] mem, size_t new_size)
 	{
-		auto sz = m_blocks.get(mem.ptr, size_t.max);
+		auto sz = m_blocks.getNothrow(mem.ptr, size_t.max);
 		assert(sz != size_t.max, "realloc() called with non-allocated pointer.");
 		assert(sz == mem.length, "realloc() called with block of wrong size.");
 		auto ret = m_baseAlloc.realloc(mem, new_size);
 		assert(ret.length == new_size, "base.realloc() returned block with wrong size.");
-		assert(ret.ptr is mem.ptr || m_blocks.get(ret.ptr, size_t.max) == size_t.max, "base.realloc() returned block that is already allocated.");
+		assert(ret.ptr is mem.ptr || m_blocks.getNothrow(ret.ptr, size_t.max) == size_t.max, "base.realloc() returned block that is already allocated.");
 		m_bytes -= sz;
 		m_blocks.remove(mem.ptr);
 		m_blocks[ret.ptr] = new_size;
@@ -183,7 +209,7 @@ final class DebugAllocator : Allocator {
 	}
 	void free(void[] mem)
 	{
-		auto sz = m_blocks.get(mem.ptr, size_t.max);
+		auto sz = m_blocks.getNothrow(mem.ptr, size_t.max);
 		assert(sz != size_t.max, "free() called with non-allocated object.");
 		assert(sz == mem.length, "free() called with block of wrong size.");
 		m_baseAlloc.free(mem);
@@ -280,7 +306,7 @@ final class AutoFreeListAllocator : Allocator {
 		Allocator m_baseAlloc;
 	}
 
-	this(Allocator base_allocator)
+	this(Allocator base_allocator) nothrow
 	{
 		m_baseAlloc = base_allocator;
 		foreach (i; iotaTuple!freeListCount)
@@ -352,7 +378,7 @@ final class PoolAllocator : Allocator {
 		size_t m_poolSize;
 	}
 
-	this(size_t pool_size, Allocator base)
+	this(size_t pool_size, Allocator base) nothrow
 	{
 		m_poolSize = pool_size;
 		m_baseAllocator = base;
@@ -392,7 +418,7 @@ final class PoolAllocator : Allocator {
 		if( !p ){
 			auto pmem = m_baseAllocator.alloc(AllocSize!Pool);
 
-			p = emplace!Pool(pmem);
+			p = emplace!Pool(cast(Pool*)pmem.ptr);
 			p.data = m_baseAllocator.alloc(max(aligned_sz, m_poolSize));
 			p.remaining = p.data;
 			p.next = cast(Pool*)m_freePools;
@@ -485,6 +511,7 @@ final class PoolAllocator : Allocator {
 
 final class FreeListAlloc : Allocator
 {
+nothrow:
 	private static struct FreeListSlot { FreeListSlot* next; }
 	private {
 		immutable size_t m_elemSize;
@@ -561,13 +588,14 @@ template FreeListObjectAlloc(T, bool USE_GC = true, bool INIT = true)
 		//logInfo("alloc %s/%d", T.stringof, ElemSize);
 		auto mem = manualAllocator().alloc(ElemSize);
 		static if( hasIndirections!T ) GC.addRange(mem.ptr, ElemSize);
-		static if( INIT ) return emplace!T(mem, args);
+		static if( INIT ) return internalEmplace!T(mem, args);
 		else return cast(TR)mem.ptr;
 	}
 
 	void free(TR obj)
 	{
 		static if( INIT ){
+			scope(failure) assert(0, "You shouldn't throw in destructors");
 			auto objc = obj;
 			.destroy(objc);//typeid(T).destroy(cast(void*)obj);
 		}
@@ -607,7 +635,7 @@ struct FreeListRef(T, bool INIT = true)
 		FreeListRef ret;
 		auto mem = manualAllocator().alloc(ElemSize + int.sizeof);
 		static if( hasIndirections!T ) GC.addRange(mem.ptr, ElemSize);
-		static if( INIT ) ret.m_object = cast(TR)emplace!(Unqual!T)(mem, args);
+		static if( INIT ) ret.m_object = cast(TR)internalEmplace!(Unqual!T)(mem, args);
 		else ret.m_object = cast(TR)mem.ptr;
 		ret.refCount = 1;
 		return ret;
@@ -681,14 +709,14 @@ struct FreeListRef(T, bool INIT = true)
 	}
 }
 
-private void* extractUnalignedPointer(void* base)
+private void* extractUnalignedPointer(void* base) nothrow
 {
 	ubyte misalign = *(cast(ubyte*)base-1);
 	assert(misalign <= Allocator.alignment);
 	return base - misalign;
 }
 
-private void* adjustPointerAlignment(void* base)
+private void* adjustPointerAlignment(void* base) nothrow
 {
 	ubyte misalign = Allocator.alignment - (cast(size_t)base & Allocator.alignmentMask);
 	base += misalign;
@@ -725,7 +753,7 @@ unittest {
 	test_align(ptr++, 0x10);
 }
 
-private size_t alignedSize(size_t sz)
+private size_t alignedSize(size_t sz) nothrow
 {
 	return ((sz + Allocator.alignment - 1) / Allocator.alignment) * Allocator.alignment;
 }
@@ -739,9 +767,58 @@ unittest {
 	}
 }
 
-private void ensureValidMemory(void[] mem)
+private void ensureValidMemory(void[] mem) nothrow
 {
 	auto bytes = cast(ubyte[])mem;
 	swap(bytes[0], bytes[$-1]);
 	swap(bytes[0], bytes[$-1]);
+}
+
+/// See issue #14194
+private T internalEmplace(T, Args...)(void[] chunk, auto ref Args args)
+	if (is(T == class))
+in {
+	import std.string, std.format;
+	assert(chunk.length >= T.sizeof,
+	       format("emplace: Chunk size too small: %s < %s size = %s",
+		      chunk.length, T.stringof, T.sizeof));
+	assert((cast(size_t) chunk.ptr) % T.alignof == 0,
+	       format("emplace: Misaligned memory block (0x%X): it must be %s-byte aligned for type %s", chunk.ptr, T.alignof, T.stringof));
+
+} body {
+    enum classSize = __traits(classInstanceSize, T);
+    auto result = cast(T) chunk.ptr;
+
+    // Initialize the object in its pre-ctor state
+    (cast(byte[]) chunk)[0 .. classSize] = typeid(T).init[];
+
+    // Call the ctor if any
+    static if (is(typeof(result.__ctor(args))))
+    {
+        // T defines a genuine constructor accepting args
+        // Go the classic route: write .init first, then call ctor
+        result.__ctor(args);
+    }
+    else
+    {
+        static assert(args.length == 0 && !is(typeof(&T.__ctor)),
+                "Don't know how to initialize an object of type "
+                ~ T.stringof ~ " with arguments " ~ Args.stringof);
+    }
+    return result;
+}
+
+/// Dittor
+private auto internalEmplace(T, Args...)(void[] chunk, auto ref Args args)
+	if (!is(T == class))
+in {
+	import std.string, std.format;
+	assert(chunk.length >= T.sizeof,
+	       format("emplace: Chunk size too small: %s < %s size = %s",
+		      chunk.length, T.stringof, T.sizeof));
+	assert((cast(size_t) chunk.ptr) % T.alignof == 0,
+	       format("emplace: Misaligned memory block (0x%X): it must be %s-byte aligned for type %s", chunk.ptr, T.alignof, T.stringof));
+
+} body {
+	return emplace(cast(T*)chunk.ptr, args);
 }


### PR DESCRIPTION
This add a bit of nothrowness in utilities (probably more to come), re-enable an unittest, and disable the new std.concurrency support when building with master (because it is simply not implemented).
There is still a LOT of nothrow to put here, and I think it'll be better to start with a small diff.

Btw, the 2 overloads of opApply would never be called. Signature selection for `opApply` is not at clever sadly :(