### PR TITLE
struct destructors are not being called

### DIFF
--- a/source/vibe/utils/memory.d
+++ b/source/vibe/utils/memory.d
@@ -597,7 +597,8 @@ template FreeListObjectAlloc(T, bool USE_GC = true, bool INIT = true)
 		static if( INIT ){
 			scope(failure) assert(0, "You shouldn't throw in destructors");
 			auto objc = obj;
-			.destroy(objc);//typeid(T).destroy(cast(void*)obj);
+			static if (is(TR == T*)) .destroy(*objc);//typeid(T).destroy(cast(void*)obj);
+			else .destroy(objc);
 		}
 		static if( hasIndirections!T ) GC.removeRange(cast(void*)obj);
 		manualAllocator().free((cast(void*)obj)[0 .. ElemSize]);


### PR DESCRIPTION
This is one of a few fixes I made in my iteration of the memory module and could have caused leaks if kept in vibe. I think there's also other occurrences in containers where elements are not destroyed properly