### PR TITLE
Assume array hold stack construction ordering

### DIFF
--- a/source/vibe/utils/memory.d
+++ b/source/vibe/utils/memory.d
@@ -85,7 +85,7 @@ void freeArray(T, bool MANAGED = true)(Allocator allocator, ref T[] array)
 		static if (hasIndirections!T)
 			GC.removeRange(array.ptr);
 		static if (hasElaborateDestructor!T)
-			foreach (ref el; array)
+			foreach_reverse (ref el; array)
 				destroy(el);
 	}
 	allocator.free(cast(void[])array);


### PR DESCRIPTION
I've started writing a pool stack and considered this as problematic if object B's destructor relies on an object owned by object A.