### PR TITLE
Exclude unsupported builds from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,16 @@ env:
   - VIBED_DRIVER=libev-travis
   - VIBED_DRIVER=libasync
 
+matrix:
+  exclude:
+    - dmd-2.065.0
+      env: VIBED_DRIVER=libasync
+    - ldc-0.14.0
+      env: VIBED_DRIVER=libasync
+    - ldc-0.15.1
+      env: VIBED_DRIVER=libasync
+    - gdc-4.9.0
+      env: VIBED_DRIVER=libasync
 script:
   - dub test --compiler=$DC --config=${VIBED_DRIVER} || exit 1
   - if [ ${VIBED_DRIVER} == "libevent" ]; then


### PR DESCRIPTION
The libasync driver is not yet ready to be built on these compilers, and I don't intend to work it out until a little later.

This will allow the vibe.d repo to go green again soon