### PR TITLE
Add example for basic authentication.

### DIFF
--- a/examples/auth_basic/dub.json
+++ b/examples/auth_basic/dub.json
@@ -1,0 +1,9 @@
+﻿{
+	"name": "auth-basic-example",
+	"description": "Demonstrates basic authentication.",
+	"authors": [ "Sönke Ludwig" ],
+	"dependencies": {
+		"vibe-d": {"version": "~master", "path": "../../"}
+	},
+	"versions": ["VibeDefaultMain"]
+}

--- a/examples/auth_basic/source/app.d
+++ b/examples/auth_basic/source/app.d
@@ -1,0 +1,30 @@
+import vibe.appmain;
+import vibe.http.auth.basic_auth;
+import vibe.http.router;
+import vibe.http.server;
+import std.functional : toDelegate;
+
+bool checkPassword(string user, string password)
+{
+	return user == "admin" && password == "secret";
+}
+
+shared static this()
+{
+	auto router = new URLRouter;
+
+	// the following routes are accessible without authentication:
+	router.get("/", staticTemplate!"index.dl");
+
+	// now any request is matched and checked for authentication:
+	router.any("*", performBasicAuth("Site Realm", toDelegate(&checkPassword)));
+
+	// the following routes can only be reached if authenticated:
+	router.get("/internal", staticTemplate!"internal.dl");
+
+	auto settings = new HTTPServerSettings;
+	settings.port = 8080;
+	settings.bindAddresses = ["::1", "127.0.0.1"];
+
+	listenHTTP(settings, router);
+}

--- a/examples/auth_basic/views/index.dl
+++ b/examples/auth_basic/views/index.dl
@@ -1,0 +1,10 @@
+doctype html
+html
+    head
+        title Basic Authentication Example
+    body
+        p Click on the 
+            a(href="/internal") link
+            | to access a protected page.
+
+

--- a/examples/auth_basic/views/internal.dl
+++ b/examples/auth_basic/views/internal.dl
@@ -1,0 +1,8 @@
+doctype html
+html
+    head
+        title Basic Authentication Example
+    body
+        p This page is protected.
+
+


### PR DESCRIPTION
This is (more or less) the example from the web site pimped with 2 templates.
The directory is named in a way that digest authentication can be easiely added as next directory (in sorted order).