### PR TITLE
Simplify @path handling

### DIFF
--- a/examples/rest/source/app.d
+++ b/examples/rest/source/app.d
@@ -154,6 +154,7 @@ interface Example3API
 	int getMyID(int id);
 }
 
+@path("/")
 interface Example3APINested
 {
 	/* In this example it will be available under "GET /nested_module/number"


### PR DESCRIPTION
- Make @rootPathAttribute the default: it just scales better, there is rarely a point in having multiples interfaces at the root.
- Kill RootPathAttribute and use PathAttribute only instead: There was no real difference between @rootPath and @path, as they were mutually exclusive (path on method, rootPath on interface) and had the same behavior (e.g. they are always relative). This will obviously make user code less error-prone.
- Communicate the settings to the sub-interface.