### PR TITLE
Add HTTP digest authentication.

### DIFF
--- a/examples/auth_digest/dub.json
+++ b/examples/auth_digest/dub.json
@@ -1,0 +1,9 @@
+﻿{
+	"name": "auth-digest-example",
+	"description": "Demonstrates digest authentication.",
+	"authors": [ "Sönke Ludwig" ],
+	"dependencies": {
+		"vibe-d": {"version": "~master", "path": "../../"}
+	},
+	"versions": ["VibeDefaultMain"]
+}

--- a/examples/auth_digest/source/app.d
+++ b/examples/auth_digest/source/app.d
@@ -1,0 +1,35 @@
+import vibe.appmain;
+import vibe.http.auth.digest_auth;
+import vibe.http.router;
+import vibe.http.server;
+import std.functional : toDelegate;
+
+string digestPassword(string realm, string user)
+{
+	if (realm == "Site Realm" && user == "admin")
+		return createDigestPassword(realm, user, "secret");
+	return "";
+}
+
+shared static this()
+{
+	auto authinfo = new DigestAuthInfo;
+	authinfo.realm = "Site Realm";
+
+	auto router = new URLRouter;
+
+	// the following routes are accessible without authentication:
+	router.get("/", staticTemplate!"index.dt");
+
+	// now any request is matched and checked for authentication:
+	router.any("*", performDigestAuth(authinfo, toDelegate(&digestPassword)));
+
+	// the following routes can only be reached if authenticated:
+	router.get("/internal", staticTemplate!"internal.dt");
+
+	auto settings = new HTTPServerSettings;
+	settings.port = 8080;
+	settings.bindAddresses = ["::1", "127.0.0.1"];
+
+	listenHTTP(settings, router);
+}

--- a/examples/auth_digest/views/index.dt
+++ b/examples/auth_digest/views/index.dt
@@ -1,0 +1,10 @@
+doctype html
+html
+    head
+        title Digest Authentication Example
+    body
+        p Click on the
+            a(href="/internal") link
+            | to access a protected page.
+
+

--- a/examples/auth_digest/views/internal.dt
+++ b/examples/auth_digest/views/internal.dt
@@ -1,0 +1,8 @@
+doctype html
+html
+    head
+        title Digest Authentication Example
+    body
+        p This page is protected.
+
+

--- a/source/vibe/http/auth/digest_auth.d
+++ b/source/vibe/http/auth/digest_auth.d
@@ -1,0 +1,158 @@
+/**
+	Implements HTTP Digest Authentication.
+
+	This is a minimal implementation based on RFC 2069.
+
+	Copyright: © 2015 RejectedSoftware e.K.
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Kai Nacke
+*/
+module vibe.http.auth.digest_auth;
+
+import vibe.http.server;
+import vibe.core.log;
+
+import std.base64;
+import std.datetime;
+import std.digest.md;
+import std.exception;
+import std.string;
+import std.uuid;
+
+enum NonceState { Valid, Expired, Invalid }
+
+class DigestAuthInfo
+{
+	string realm;
+	ubyte[] secret;
+	ulong timeout;
+
+	this()
+	{
+		secret = randomUUID().data.dup;
+		timeout = 300;
+	}
+
+	string createNonce(in HTTPServerRequest req)
+	{
+		auto now = Clock.currTime(UTC()).stdTime();
+		auto time = *cast(ubyte[now.sizeof]*)&now;
+		MD5 md5;
+		md5.put(time);
+		md5.put(secret);
+		auto data = md5.finish();
+		return Base64.encode(time ~ data);
+	}
+
+	NonceState checkNonce(in string nonce, in HTTPServerRequest req)
+	{
+		auto now = Clock.currTime(UTC()).stdTime();
+		ubyte[] decoded = Base64.decode(nonce);
+		if (decoded.length != now.sizeof + secret.length) return NonceState.Invalid;
+		auto time = decoded[0..now.sizeof];
+		if (timeout + *cast(typeof(now)*)time.ptr > now) return NonceState.Expired;
+		MD5 md5;
+		md5.put(time);
+		md5.put(secret);
+		auto data = md5.finish();
+		if (data[] != decoded[now.sizeof..$]) return NonceState.Invalid;
+		return NonceState.Valid;
+	}
+}
+
+private bool checkDigest(HTTPServerRequest req, DigestAuthInfo info, string delegate(string realm, string user) pwhash, out bool stale, out string username)
+{
+	stale = false;
+        username = "";
+	auto pauth = "Authorization" in req.headers;
+	if (pauth && (*pauth).startsWith("Digest ")) {
+		string realm, nonce, response, uri, algorithm;
+		foreach (param; split((*pauth)[7 .. $], ",")) {
+			auto kv = split(param, "=");
+			if( kv[0] == "realm") realm = kv[1][1..$-1];
+			if( kv[0] == "username") username = kv[1][1..$-1];
+			if( kv[0] == "nonce") nonce = kv[1][1..$-1];
+			if( kv[0] == "uri") uri = kv[1][1..$-1];
+			if( kv[0] == "response") response = kv[1][1..$-1];
+			if( kv[0] == "algorithm") algorithm = kv[1][1..$-1];
+		}
+
+		if (realm != info.realm)
+			return false;
+		if (algorithm !is null && algorithm != "MD5")
+			return false;
+		auto nonceState = info.checkNonce(nonce, req);
+		if (nonceState != NonceState.Valid) {
+			stale = nonceState == NonceState.Expired;
+			return false;
+		}
+		auto ha1 = pwhash(realm, username);
+		auto ha2 = toHexString!(LetterCase.lower)(md5Of(httpMethodString(req.method) ~ ":" ~ uri));
+		auto calcresponse = toHexString!(LetterCase.lower)(md5Of(ha1 ~ ":" ~ nonce ~ ":" ~ ha2 ));
+		if (response[] == calcresponse[])
+			return true;
+	}
+	return false;
+}
+
+/**
+	Returns a request handler that enforces request to be authenticated using HTTP Digest Auth.
+*/
+HTTPServerRequestDelegate performDigestAuth(DigestAuthInfo info, string delegate(string realm, string user) pwhash)
+{
+	void handleRequest(HTTPServerRequest req, HTTPServerResponse res)
+	{
+		bool stale;
+		string username;
+		if (checkDigest(req, info, pwhash, stale, username)) {
+			req.username = username;
+			return ;
+		}
+
+		// else output an error page
+		res.statusCode = HTTPStatus.unauthorized;
+		res.contentType = "text/plain";
+		res.headers["WWW-Authenticate"] = "Digest realm=\""~info.realm~"\", nonce=\""~info.createNonce(req)~"\", stale="~(stale?"true":"false");
+		res.bodyWriter.write("Authorization required");
+	}
+	return &handleRequest;
+}
+
+/**
+	Enforces HTTP Digest Auth authentication on the given req/res pair.
+
+	Params:
+		req = Request object that is to be checked
+		res = Response object that will be used for authentication errors
+		info = Digest authentication info object
+		pwhash = A delegate queried for returning the digest password
+
+	Returns: Returns the name of the authenticated user.
+
+	Throws: Throws a HTTPStatusExeption in case of an authentication failure.
+*/
+string performDigestAuth(HTTPServerRequest req, HTTPServerResponse res, DigestAuthInfo info, string delegate(string realm, string user) pwhash)
+{
+	bool stale;
+	string username;
+	if (checkDigest(req, info, pwhash, stale, username))
+		return username;
+
+	res.headers["WWW-Authenticate"] = "Digest realm=\""~info.realm~"\", nonce=\""~info.createNonce(req)~"\", stale="~(stale?"true":"false");
+	throw new HTTPStatusException(HTTPStatus.unauthorized);
+}
+
+/**
+	Creates the digest password from the user name, realm and password.
+
+	Params:
+		realm = The realm
+		user = The user name
+		password = The plain text password
+
+	Returns: Returns the digest password
+*/
+string createDigestPassword(string realm, string user, string password)
+{
+	return toHexString!(LetterCase.lower)(md5Of(user ~ ":" ~ realm ~ ":" ~ password)).dup;
+}


### PR DESCRIPTION
This is a minimal implementation of RFC 2069.

Possible future enhancements:
- Add the client IP to the nonce
- Implement qpop
- Retrieve user passwords from .htaccess file