### PR TITLE
Enable default block content in Diet templates

### DIFF
--- a/source/vibe/templ/diet.d
+++ b/source/vibe/templ/diet.d
@@ -605,7 +605,6 @@ private struct DietCompiler(TRANSLATE...)
 						output.pushNode("<![endif]-->");
 						break;
 					case "block": // Block insertion place
-						assertp(next_indent_level <= level, "Child elements for 'include' are not supported.");
 						output.pushDummyNode();
 						auto block = getBlock(ln[6 .. $].ctstrip());
 						if( block ){


### PR DESCRIPTION
With Jade templates, you can define a default block content which is used if no content for a block is provided.
This is also possible with vibe.d - but an assertion prevents this.
IMHO the assertion is a cut'n'paste error. Removing it enables use of default block content.