### PR TITLE
Fix output of block comments

### DIFF
--- a/source/vibe/templ/diet.d
+++ b/source/vibe/templ/diet.d
@@ -584,7 +584,19 @@ private struct DietCompiler(TRANSLATE...)
 					case "//": // HTML comment
 						skipWhitespace(ln, j);
 						output.writeString("<!-- " ~ htmlEscape(ln[j .. $]));
+						size_t next_tag = m_lineIndex+1;
+						while( next_tag < lineCount &&
+							indentLevel(line(next_tag).text, indentStyle, false) - start_indent_level > level-base_level )
+						{
+							output.writeString("\n");
+							output.writeStringHtmlEscaped(line(next_tag).text);
+							next_tag++;
+						}
 						output.pushNode(" -->");
+
+						// skip to the next tag
+						m_lineIndex = next_tag-1;
+						next_indent_level = computeNextIndentLevel();
 						break;
 					case "//-": // non-output comment
 						// find all child lines


### PR DESCRIPTION
A block comment

    body
      //
        Line 1
        Line 2

should be rendered as

    <body>
        <!--
          Line 1
          Line 2
        -->
    </body>

Currently, the block content is treated as normal template code.

This PR fixes the output behaviour.