### PR TITLE
Allow only set of one id at tag in Diet template.

### DIFF
--- a/source/vibe/templ/diet.d
+++ b/source/vibe/templ/diet.d
@@ -1013,6 +1013,14 @@ private struct DietCompiler(TRANSLATE...)
 			else break;
 		}
 
+		// check for multiple occurances of id
+		bool has_id = false;
+		foreach( a; attribs )
+			if( a.key == "id" ) {
+				assertp(!has_id, "Id may only be set once.");
+				has_id = true;
+			}
+
 		// add special attribute for extra classes that is handled by buildHtmlTag
 		if( classes.length ){
 			bool has_class = false;


### PR DESCRIPTION
Currently, the template checks only this pattern:

    tag#id1#id2

but not the patterns

    tag#id1(id='id2')
    tag(id='id1',id='id2')

This PR adds a check to enforce setting of id only once.