### PR TITLE
Remove deprecation notice for index handling in vibe.web.rest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs.json
 /docs/prettify
 /docs/scripts
 /docs/styles
+__dummy.html
 
 .dub
 dub.selections.json
@@ -22,8 +23,7 @@ dub.selections.json
 # Unittest binaries
 vibe-d
 tests/*/tests
-__test__libevent__
-__test__libev__
+__test__*__
 
 # Examples
 examples/app_skeleton/__test__library__

--- a/source/vibe/web/rest.d
+++ b/source/vibe/web/rest.d
@@ -32,22 +32,22 @@ import std.typetuple : anySatisfy, Filter;
 
 	The following table lists the mappings from prefix verb to HTTP verb:
 
-	<table>
-		<tr><th>Prefix</th><th>HTTP verb</th></tr>
-		<tr><td>get</td><td>GET</td></tr>
-		<tr><td>query</td><td>GET</td></tr>
-		<tr><td>set</td><td>PUT</td></tr>
-		<tr><td>put</td><td>PUT</td></tr>
-		<tr><td>update</td><td>PATCH</td></tr>
-		<tr><td>patch</td><td>PATCH</td></tr>
-		<tr><td>add</td><td>POST</td></tr>
-		<tr><td>create</td><td>POST</td></tr>
-		<tr><td>post</td><td>POST</td></tr>
-	</table>
+	$(TABLE
+		$(TR $(TH Prefix) $(TH HTTP verb))
+		$(TR $(TD get)	  $(TD GET))
+		$(TR $(TD query)  $(TD GET))
+		$(TR $(TD set)    $(TD PUT))
+		$(TR $(TD put)    $(TD PUT))
+		$(TR $(TD update) $(TD PATCH))
+		$(TR $(TD patch)  $(TD PATCH))
+		$(TR $(TD add)    $(TD POST))
+		$(TR $(TD create) $(TD POST))
+		$(TR $(TD post)   $(TD POST))
+	)
 
 	If a method has its first parameter named 'id', it will be mapped to ':id/method' and
-    'id' is expected to be part of the URL instead of a JSON request. Parameters with default
-    values will be optional in the corresponding JSON request.
+	'id' is expected to be part of the URL instead of a JSON request. Parameters with default
+	values will be optional in the corresponding JSON request.
 
 	Any interface that you return from a getter will be made available with the
 	base url and its name appended.
@@ -58,7 +58,7 @@ import std.typetuple : anySatisfy, Filter;
 			must either be an interface type, or a class which derives from a
 			single interface
 		settings = Additional settings, such as the $(D MethodStyle), or the prefix.
-                           See $(D RestInterfaceSettings) for more details.
+			See $(D RestInterfaceSettings) for more details.
 
 	See_Also:
 		$(D RestInterfaceClient) class for a seamless way to access such a generated API

--- a/source/vibe/web/rest.d
+++ b/source/vibe/web/rest.d
@@ -112,19 +112,12 @@ void registerRestInterface(TImpl)(URLRouter router, TImpl instance, RestInterfac
 	foreach (method; __traits(allMembers, I)) {
 		foreach (overload; MemberFunctionsTuple!(I, method)) {
 
-			enum meta = extractHTTPMethodAndName!overload();
+			enum meta = extractHTTPMethodAndName!(overload, false)();
 
 			static if (meta.hadPathUDA) {
 				string url = meta.url;
 			}
 			else {
-				static if (__traits(identifier, overload) == "index") {
-					pragma(msg, "Processing interface " ~ I.stringof ~
-						": please use @path(\"/\") to define '/' path" ~
-						" instead of 'index' method. Special behavior will be removed" ~
-						" in the next release.");
-				}
-
 				string url = adjustMethodStyle(strip(meta.url), settings.methodStyle);
 			}
 
@@ -817,7 +810,7 @@ private string generateRestInterfaceSubInterfaceInstances(I)()
 					tps ~= RT.stringof;
 					string implname = RT.stringof ~ "Impl";
 
-					enum meta = extractHTTPMethodAndName!overload();
+					enum meta = extractHTTPMethodAndName!(overload, false)();
 
 					ret ~= q{
 						auto settings_%1$s = m_settings.dup;
@@ -922,7 +915,7 @@ private string genClientBody(alias Func)() {
 	alias PTT = ParameterTypeTuple!Func;
 	alias ParamNames = ParameterIdentifierTuple!Func;
 
-	enum meta = extractHTTPMethodAndName!Func();
+	enum meta = extractHTTPMethodAndName!(Func, false)();
 	enum paramAttr = UDATuple!(WebParamAttribute, Func);
 	enum FuncId = __traits(identifier, Func);
 

--- a/source/vibe/web/web.d
+++ b/source/vibe/web/web.d
@@ -127,7 +127,7 @@ void registerWebInterface(C : Object, MethodStyle method_style = MethodStyle.low
 		static if (!is(typeof(__traits(getMember, Object, M)))) { // exclude Object's default methods and field
 			foreach (overload; MemberFunctionsTuple!(C, M)) {
 				alias RT = ReturnType!overload;
-				enum minfo = extractHTTPMethodAndName!overload();
+				enum minfo = extractHTTPMethodAndName!(overload, true)();
 				enum url = minfo.hadPathUDA ? minfo.url : adjustMethodStyle(minfo.url, method_style);
 
 				static if (is(RT == class) || is(RT == interface)) {


### PR DESCRIPTION
This had been deprecated in fe6a5de7433140660b14af28e9540b22c198c1c7 and so this message is there since July 2013 (and not relevant anymore). Time to remove it ?