### PR TITLE
Update libasync dependency with memutils

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -38,7 +38,7 @@
 		},
 		{
 			"name": "libasync",
-			"dependencies": {"libasync": "0.7.0" },
+			"dependencies": {"libasync": "0.7.1" },
 			"versions": ["VibeUseNativeDriverType", "VibeLibasyncDriver"]
 		},
 		{

--- a/dub.json
+++ b/dub.json
@@ -38,7 +38,7 @@
 		},
 		{
 			"name": "libasync",
-			"dependencies": {"libasync": "0.7.1" },
+			"dependencies": {"libasync": "0.7.1"},
 			"versions": ["VibeUseNativeDriverType", "VibeLibasyncDriver"]
 		},
 		{


### PR DESCRIPTION
This update adds memutils as a dependency. I intend to use it where libasync and its driver use HashMap, Array, FreeListRef and other manual memory operations. I've already started separating the vibe.d manual memory management from the libasync memory management with the last pull regarding DMD 2.67.0 compatibility fixes.

The new memory management is mostly based on your code, but it adds Phobos containers including red black tree and array, along with improvements in user experience for reference counting and object embedding (`alias this T` => `mixin Embed!T`). This will probably be used to implement the timers directly in libasync. It also implements scoped pools which are used to override the GC in tree-like structures such as [DOM, Json and XML parsing](https://github.com/etcimon/spd). This currently works using `alloc!T` instead of `new T` and pools are created in scope using `auto p = ScopedPool();`, freeing the memory as they go out of scope and calling destructors properly. As for appenders, they are effectively replaced by a `Vector!T` in Botan, and what's left is to make them copied on the scoped pools or GC with `.copy()`. I'm still unsure how I'm going to handle "Deep Copy", and overriding the duplication process.

I'd like to eventually use this for the redis client, hibernated and other protocols that currently rely on the GC.