### PR TITLE
Add rawResume

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -512,6 +512,17 @@ void rawYield()
 }
 
 /**
+	Resumes a task that was paused with $(D rawYield) on the next run of the
+	event loop.
+*/
+void rawResume(Task t, Exception ex = null)
+{
+	CoreTask ct = cast(CoreTask)t.fiber;
+	ct.m_exception = ex;
+	s_yieldedTasks.insertBack(ct);
+}
+
+/**
 	Suspends the execution of the calling task for the specified amount of time.
 
 	Note that other tasks of the same thread will continue to run during the


### PR DESCRIPTION
The HTTP/2 driver manages stream lifetime similar to a TCP connection. I have a read/write event loop and tasks opened for every subsequent inter-connection streams. When these tasks need to write through the HTTP/2 protocol, they might yield just like within the TCP Connection.

See here to see how the task is stopped: 
https://github.com/etcimon/vibe.d/blob/c064f3bafc43ea824206d2ecbe2eba4ea0163012/source/vibe/http/http2.d#L250

And how the task is resumed once the buffers are flushed:
https://github.com/etcimon/vibe.d/blob/c064f3bafc43ea824206d2ecbe2eba4ea0163012/source/vibe/http/http2.d#L88

I want the read/write loops to leave those tasks untouched, but I don't want to acquire locks in the process of context switching because those are guaranteed to be single-threaded operations.

For this reason, I'd like to add the `rawResume` feature which schedules the stream resumption before the event loop blocks in the OS.