### PR TITLE
Fix exitEventLoop and synchronization unittest issues in libasync

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -964,7 +964,6 @@ private class CoreTask : TaskFiber {
 					debug if (s_taskEventCallback) s_taskEventCallback(TaskEvent.start, handle);
 					if (!s_eventLoopRunning) {
 						logTrace("Event loop not running at task start - yielding.");
-						assert(!m_queue);
 						.yield();
 						logTrace("Initial resume of task.");
 					}

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -120,7 +120,6 @@ final class LibasyncDriver : EventDriver {
 		while(!m_break && getEventLoop().loop()){
 			getDriverCore().notifyIdle();
 		}
-		getEventLoop().exit();
 		m_break = false;
 		logInfo("Event loop exit", m_break);
 		return 0;

--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -540,6 +540,7 @@ final class SyslogLogger : Logger {
 		}
 
 		assert(msg.level >= LogLevel.debug_);
+		import std.conv : to; // temporary workaround for issue 1016 (DMD cross-module template overloads error out before second attempted module)
 		auto priVal = (m_facility * 8 + syslogSeverity).to!string();
 
 		alias procId = NILVALUE;

--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -354,6 +354,7 @@ private void runMutexUnitTests(M)()
 		assert(m.m_impl.m_locked);
 		t1.join();
 		assert(!t1.running && t2.running);
+		yield();
 		assert(m.m_impl.m_locked);
 		t2.join();
 		assert(!t2.running);


### PR DESCRIPTION
The `assert(!m_queue)` assumes that the task wasn't initialized yet if the event loop isn't running. Now that the event loop can be turned on and off, this isn't true anymore.

The `yield()` was added in the test because the Task unlocking mechanism doesn't generate yielding in the libasync driver, nor does it trigger a kernel signal to pause the thread and process the locking queue after an unlock. This is voluntary behavior, the TaskMutex lock waiter queue will be processed at the next run of the event loop and any lock-holding tasks will resume at that time. Yielding at ManualEvent.emit() would (maybe) process those locks instantly (depending on the ordering of tasks to be resume) but may also create unnecessary performance issues.

Finally, the `getEventLoop().exit()` was in `exitEventLoop()` by mistake, I was under the impression that it would only be called when the program must exit, thus the underlying file descriptors were being destroyed there. Vibe applications can turn on and off the event loop safely now.