### PR TITLE
Ran Valgrind on libasync http_server

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -39,7 +39,7 @@
 		},
 		{
 			"name": "libasync",
-			"dependencies": {"libasync": "0.7.1"},
+			"dependencies": {"libasync": "0.7.2"},
 			"versions": ["VibeUseNativeDriverType", "VibeLibasyncDriver"]
 		},
 		{

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -1053,6 +1053,7 @@ final class LibasyncTCPConnection : TCPConnection {
 		auto tm = _driver.createTimer(null);
 		scope(exit) { 
 			_driver.releaseTimer(tm);
+			_driver.processTimers();
 			releaseReader();
 		}
 		_driver.m_timers.getUserData(tm).owner = Task.getThis();


### PR DESCRIPTION
The leak would cause memory usage to spike on apachebench/linux configurations. The timers were not being removed early enough, so a new fix processes them early.