### PR TITLE
fix mistype : examples/websocket/public/index.html

### DIFF
--- a/examples/websocket/public/index.html
+++ b/examples/websocket/public/index.html
@@ -14,4 +14,4 @@
 	<pre id="timer"></pre>
 	<button type="button" onclick="closeConnection()">Close connection</button>
 </body>
-</htnl>
+</html>


### PR DESCRIPTION
I found mistype in examples/websocket/public/index.html

Original:
\</htnl\>
Fixed:
\</html\>