### PR TITLE
Added REPORT method for webDAV

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -52,7 +52,8 @@ enum HTTPMethod {
 	MOVE,
 	PROPFIND,
 	PROPPATCH,
-	UNLOCK
+	UNLOCK,
+	REPORT
 }
 
 
@@ -87,6 +88,7 @@ HTTPMethod httpMethodFromString(string str)
 		case "PROPFIND": return HTTPMethod.PROPFIND;
 		case "PROPPATCH": return HTTPMethod.PROPPATCH;
 		case "UNLOCK": return HTTPMethod.UNLOCK;
+		case "REPORT": return HTTPMethod.REPORT;
 	}
 }
 


### PR DESCRIPTION
Some webDav extensions use the REPORT method to get information about
the existing resources