### PR TITLE
Returns TCPListener's from http listener. Solves #1074.

### DIFF
--- a/source/vibe/http/dist.d
+++ b/source/vibe/http/dist.d
@@ -23,7 +23,7 @@ import std.process;
 
 	This function is usable as direct replacement of 
 */
-void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handler, string balancer_address, ushort balancer_port = 11000)
+TCPListener[] listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handler, string balancer_address, ushort balancer_port = 11000)
 {
 	Json regmsg = Json.emptyObject;
 	regmsg.host_name = settings.hostName;
@@ -36,7 +36,7 @@ void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handl
 	local_settings.bindAddresses = ["127.0.0.1"];
 	local_settings.port = 0;
 	local_settings.disableDistHost = true;
-	listenHTTP(local_settings, handler);
+	TCPListener[] listener = listenHTTP(local_settings, handler);
 
 	requestHTTP(URL("http://"~balancer_address~":"~to!string(balancer_port)~"/register"), (scope req){
 			logInfo("Listening for VibeDist connections on port %d", req.localAddress.port);
@@ -47,4 +47,6 @@ void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handl
 		}, (scope res){
 			enforce(res.statusCode == HTTPStatus.ok, "Failed to register with load balancer.");
 		});
+	
+	return listener;
 }


### PR DESCRIPTION
Untested post http-server-example usage.
It shouldn't break anything in the wild, as it is changing void return type to TCPListener[].

Related issue: #1074

This doesn't fulfill @etcimon's use case.