### PR TITLE
Extend synchronized/nothrow workaround to DMD 2.068

### DIFF
--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -624,7 +624,7 @@ final class Libevent2ManualEvent : Libevent2Object, ManualEvent {
 		// Since 2068, synchronized statements are annotated nothrow.
 		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
 		// However, they were "logically" nothrow before.
-		static if (__VERSION__ <= 2067)
+		static if (__VERSION__ <= 2068)
 			scope (failure) assert(0, "Internal error: function should be nothrow");
 
 		atomicOp!"+="(m_emitCount, 1);

--- a/source/vibe/utils/memory.d
+++ b/source/vibe/utils/memory.d
@@ -125,7 +125,7 @@ class LockAllocator : Allocator {
 		// Since 2068, synchronized statements are annotated nothrow.
 		// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
 		// However, they were "logically" nothrow before.
-		static if (__VERSION__ <= 2067)
+		static if (__VERSION__ <= 2068)
 			scope (failure) assert(0, "Internal error: function should be nothrow");
 
 		synchronized (this)
@@ -140,7 +140,7 @@ class LockAllocator : Allocator {
 			// Since 2068, synchronized statements are annotated nothrow.
 			// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
 			// However, they were "logically" nothrow before.
-			static if (__VERSION__ <= 2067)
+			static if (__VERSION__ <= 2068)
 				scope (failure) assert(0, "Internal error: function should be nothrow");
 
 			synchronized(this)
@@ -155,7 +155,7 @@ class LockAllocator : Allocator {
 			// Since 2068, synchronized statements are annotated nothrow.
 			// DMD#4115, Druntime#1013, Druntime#1021, Phobos#2704
 			// However, they were "logically" nothrow before.
-			static if (__VERSION__ <= 2067)
+			static if (__VERSION__ <= 2068)
 				scope (failure) assert(0, "Internal error: function should be nothrow");
 			synchronized(this)
 				m_base.free(mem);


### PR DESCRIPTION
See issue #1098.