### PR TITLE
Use Content-Length Header in Form Uploads

### DIFF
--- a/source/vibe/inet/webform.d
+++ b/source/vibe/inet/webform.d
@@ -190,8 +190,7 @@ private bool parseMultipartFormPart(InputStream stream, ref FormFields form, ref
 			long to_read;
 			do {
 				to_read = min(len, buf.length);
-				stream.read(buf[0 .. to_read]);
-				file.write(buf[0 .. to_read]);
+				file.write(stream, to_read);
 				len -= to_read;
 			} while (to_read == buf.length && len > 0);
 		}

--- a/source/vibe/inet/webform.d
+++ b/source/vibe/inet/webform.d
@@ -185,14 +185,7 @@ private bool parseMultipartFormPart(InputStream stream, ref FormFields form, ref
 		fp.tempPath = file.path;
 		if (auto plen = "Content-Length" in headers) {
 			import std.conv : to;
-			long len = (*plen).to!long;
-			ubyte[1024] buf = void;
-			long to_read;
-			do {
-				to_read = min(len, buf.length);
-				file.write(stream, to_read);
-				len -= to_read;
-			} while (to_read == buf.length && len > 0);
+			file.write(stream, (*plen).to!long);
 		}
 		else stream.readUntil(file, cast(ubyte[])boundary);
 		logDebug("file: %s", fp.tempPath.toString());


### PR DESCRIPTION
This optimization takes advantage of Content-Length if provided and avoids many calls to read/write, which gives me a 20% performance improvement.