### PR TITLE
Header write being skipped on clients causes a connection freeze

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -989,6 +989,8 @@ final class HTTPClientRequest : HTTPRequest {
 
 		// http/2
 		if (isHTTP2) {
+			if (auto pka = "Connection" in headers)
+				headers.remove("Connection");
 			logDebug("Writing HTTP/2 headers");
 			http2Stream.writeHeader(requestURL, tlsStream ? "https" : "http", method, headers, m_cookieJar, m_concatCookies);
 			return;

--- a/source/vibe/http/http2.d
+++ b/source/vibe/http/http2.d
@@ -1865,16 +1865,18 @@ private:
 							stream.m_rx.ex = new Exception("Push Promise being sent by client stream... and with no headers.");
 						// header request/response/push-response
 						} else {
+							bool is_push;
 							// Clients: Is possible that we received this request as a push response?
 							if (!isServer) {
 								// To verify, we "pop" the push response that corresponds to this stream's headers, or null if none
 								if (HTTP2Stream push_stream = popPushResponse(stream)) {
+									is_push = true;
 									assert(!isServer);
 									stream.readPushResponse(push_stream);
 								}
 							}
 							// header request/response
-							else 
+							if (!is_push) 
 							{ 
 								if (close) close_processed = true;
 								prispec_processed = true;

--- a/source/vibe/http/proxy.d
+++ b/source/vibe/http/proxy.d
@@ -71,7 +71,8 @@ HTTPServerRequestDelegateS reverseProxyRequest(HTTPReverseProxySettings settings
 		{
 			creq.method = req.method;
 			creq.headers = req.headers.dup;
-			creq.headers["Connection"] = "keep-alive";
+			if (!creq.isHTTP2)
+				creq.headers["Connection"] = "keep-alive";
 			creq.headers["Host"] = settings.destinationHost;
 			if (settings.avoidCompressedRequests && "Accept-Encoding" in creq.headers)
 				creq.headers.remove("Accept-Encoding");


### PR DESCRIPTION
I'm currently writing more high-level tests (reverse proxy) and finding a lot of new issues with HTTP/2 and the client. Seems like I'll be adding more soon enough, it seems like a good way to validate the code.