### PR TITLE
Add optional reason message and code to WebSocket.close

### DIFF
--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -298,12 +298,12 @@ final class WebSocket {
 		Actively closes the connection.
 
 		Params:
-			reason = Message describing why the connection was terminated.
 			code = Numeric code indicating a termination reason.
+			reason = Message describing why the connection was terminated.
 	*/
-	void close(string reason = "", short code = 0)
+	void close(short code = 0, string reason = "")
 	{
-		//payload lengths >= 126 causes an error, but only on close frames?
+		//control frame payloads are limited to 125 bytes
 		assert(reason.length <= 123);
 
 		if (connected) {
@@ -311,7 +311,8 @@ final class WebSocket {
 				m_sentCloseFrame = true;
 				Frame frame;
 				frame.opcode = FrameOpcode.close;
-				frame.payload = std.bitmanip.nativeToBigEndian(code) ~ cast(ubyte[])reason;
+				if(code != 0)
+					frame.payload = std.bitmanip.nativeToBigEndian(code) ~ cast(ubyte[])reason;
 				frame.fin = true;
 				frame.writeFrame(m_conn);
 			});

--- a/source/vibe/http/websockets.d
+++ b/source/vibe/http/websockets.d
@@ -296,14 +296,22 @@ final class WebSocket {
 
 	/**
 		Actively closes the connection.
+
+		Params:
+			reason = Message describing why the connection was terminated.
+			code = Numeric code indicating a termination reason.
 	*/
-	void close()
+	void close(string reason = "", short code = 0)
 	{
+		//payload lengths >= 126 causes an error, but only on close frames?
+		assert(reason.length <= 123);
+
 		if (connected) {
 			m_writeMutex.performLocked!({
 				m_sentCloseFrame = true;
 				Frame frame;
 				frame.opcode = FrameOpcode.close;
+				frame.payload = std.bitmanip.nativeToBigEndian(code) ~ cast(ubyte[])reason;
 				frame.fin = true;
 				frame.writeFrame(m_conn);
 			});


### PR DESCRIPTION
Not sure why the payload length is limited to 125 bytes. Regular messages can be longer, so it doesn't seem to be an issue with vibe code. I found no mention of such a limit for close frames in the RFC.