### PR TITLE
Fix zlib output stream

### DIFF
--- a/source/vibe/stream/zlib.d
+++ b/source/vibe/stream/zlib.d
@@ -93,7 +93,7 @@ class ZlibOutputStream : OutputStream {
 		if (m_finalized) return;
 		m_finalized = true;
 		doFlush(Z_FINISH);
-		m_out.flush();
+		m_out.finalize();
 		zlibEnforce(deflateEnd(&m_zstream));
 	}
 


### PR DESCRIPTION
The finalize instruction will ensure that `ChunkedOutputStream` prints `0\r\n\r\n`