### PR TITLE
Zlib memory leak and leastsize assertion

### DIFF
--- a/source/vibe/stream/zlib.d
+++ b/source/vibe/stream/zlib.d
@@ -63,6 +63,11 @@ class ZlibOutputStream : OutputStream {
 		zlibEnforce(deflateInit2(&m_zstream, level, Z_DEFLATED, 15 + (type == HeaderFormat.gzip ? 16 : 0), 8, Z_DEFAULT_STRATEGY));
 	}
 
+	~this() {
+		if (!m_finalized)
+			deflateEnd(&m_zstream);
+	}
+
 	final void write(in ubyte[] data)
 	{
 		if (!data.length) return;
@@ -184,6 +189,11 @@ class ZlibInputStream : InputStream {
 		}
 	}
 
+	~this() {
+		if (!m_finished)
+			inflateEnd(&m_zstream);
+	}
+
 	@property bool empty() { return this.leastSize == 0; }
 
 	@property ulong leastSize()
@@ -192,7 +202,7 @@ class ZlibInputStream : InputStream {
 		if (m_outbuffer.length > 0) return m_outbuffer.length;
 		if (m_finished) return 0;
 		readChunk();
-		assert(m_outbuffer.length || m_finished);
+
 		return m_outbuffer.length;
 	}
 
@@ -245,6 +255,7 @@ class ZlibInputStream : InputStream {
 
 			if (ret == Z_STREAM_END) {
 				m_finished = true;
+				zlibEnforce(inflateEnd(&m_zstream));
 				assert(m_in.empty, "Input expected to be empty at this point.");
 				return;
 			}


### PR DESCRIPTION
This fixes an issue where zlib is not guaranteed to call deflateEnd or inflateEnd.

It also fixes an assertion failure that occurs when the underlying stream is closed prematurely.