### PR TITLE
support ulong values for Json

### DIFF
--- a/examples/json/source/app.d
+++ b/examples/json/source/app.d
@@ -1,6 +1,7 @@
 ﻿import vibe.data.json;
 
 import std.stdio;
+import std.bigint;
 
 void main()
 {
@@ -17,4 +18,8 @@ void main()
 	Json parent = obj;
 	parent.remove("item1");
 	foreach (i; obj) writeln(i);
+
+	auto obj2 = parseJsonString(`{"serial":17559991181826658461}`);
+	writeln("serial: ", obj2["serial"]);
+	assert(obj2["serial"] == BigInt(17559991181826658461UL));
 }

--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -1603,6 +1603,7 @@ private Bson.Type jsonTypeToBsonType(Json.Type tp)
 		Bson.Type.null_,
 		Bson.Type.bool_,
 		Bson.Type.long_,
+		Bson.Type.long_,
 		Bson.Type.double_,
 		Bson.Type.string,
 		Bson.Type.array,
@@ -1623,6 +1624,9 @@ private Bson.Type writeBson(R)(ref R dst, in Json value)
 			dst.put(cast(ubyte)(cast(bool)value ? 0x01 : 0x00));
 			return Bson.Type.bool_;
 		case Json.Type.int_:
+			dst.put(toBsonData(cast(long)value));
+			return Bson.Type.long_;
+		case Json.Type.bigint:
 			dst.put(toBsonData(cast(long)value));
 			return Bson.Type.long_;
 		case Json.Type.float_:

--- a/tests/redis/source/app.d
+++ b/tests/redis/source/app.d
@@ -3,7 +3,7 @@
 module app;
 
 import vibe.vibe;
-import std.algorithm : sort;
+import std.algorithm : sort, equal;
 
 void runTest()
 {


### PR DESCRIPTION
Hello, Vibe.D!

I've written about my problem on forum: http://forum.rejectedsoftware.com/groups/rejectedsoftware.vibed/thread/25482/

I use vibe.d on small commercial product, and two days ago I got this trouble.
One REST server (api.shodan.io) sent me a JSON like `{..., serial: 17559991181826658461, ...}`
I read the official JSON standard: http://json.org/
Unfortunately, it doesn't define bounds for a number value, thus `99999999999999999999999999` is a correct JSON value.
However the most real systems uses 64-bit (as maximum) signed and unsigned integers for describe integral values.
Thus, supporting of ulong is very needed for users.

I've added a new `Type` value: `uint_`, which represents `ulong` values.
I prefer `int_` type instead of `uint_` when it possible.
If the integral value x <= long.max, I write is to Json as `int_` even if it hasn't the sign.

If this way is unacceptable, please suggest another way to parse ulong values.
We may convert it to long or to string.
Get an exception during parsing of correct JSON answer of a REST server is very, because I can't get the REST answer as string (using `vibe.web.rest`) and parse it manually.
Thanks.