### PR TITLE
fix BigInt initialization

### DIFF
--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -198,7 +198,14 @@ struct Json {
 	/// ditto
 	long opAssign(long v) { runDestructors(); m_type = Type.int_; m_int = v; return v; }
 	/// ditto
-	BigInt opAssign(BigInt v) { runDestructors(); m_type = Type.bigInt; m_bigInt = v; return v; }
+	BigInt opAssign(BigInt v)
+	{
+		if (m_type != Type.bigInt)
+			initBigInt();
+		m_type = Type.bigInt;
+		m_bigInt = v;
+		return v;
+	}
 	/// ditto
 	double opAssign(double v) { runDestructors(); m_type = Type.float_; m_float = v; return v; }
 	/// ditto


### PR DESCRIPTION
[835f545](https://github.com/rejectedsoftware/vibe.d/commit/835f545fc4e4d0577cf32a251625ff96624424d6#diff-86df8637c7aa11d44c494d012fd79d09L254) raises an [error](https://travis-ci.org/rejectedsoftware/vibe.d/jobs/65295311) with ldc. This PR fixes it.