### PR TITLE
REST header serialization, optional REST parameters

### DIFF
--- a/source/vibe/utils/dictionarylist.d
+++ b/source/vibe/utils/dictionarylist.d
@@ -59,6 +59,12 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 		foreach (k, ref v; this) ret ~= FieldTuple(k, v);
 		return ret;
 	}
+	/// ditto
+	const(FieldTuple)[] toRepresentation() const {
+		const(FieldTuple)[] ret;
+		foreach (k, ref v; this) ret ~= const(FieldTuple)(k, v);
+		return ret;
+	}
 
 	/** Removes the first field that matches the given key.
 	*/


### PR DESCRIPTION
This fixes the way REST headers are serialized (converting to literal values or JSON, instead of just calling `.toString()`), while also adding the ability to have optional parameters in REST methods, akin to the web interface.

Also added is a `const` version of `toRepresentation` of `DictionaryList`.