### PR TITLE
Add websockets and CONNECT tunnel support to the HTTP proxy

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1036,6 +1036,25 @@ final class HTTPServerResponse : HTTPResponse {
 		m_rawConnection.close(); // connection not reusable after a protocol upgrade
 	}
 
+	/** Special method for handling CONNECT proxy tunnel
+
+		Notice: For the overload that returns a `ConnectionStream`, it must be
+			ensured that the returned instance doesn't outlive the request
+			handler callback.
+	*/
+	ConnectionStream connectProxy()
+	{
+		return new ConnectionProxyStream(m_conn, m_rawConnection);
+	}
+	/// ditto
+	void connectProxy(scope void delegate(scope ConnectionStream) del)
+	{
+		scope conn = new ConnectionProxyStream(m_conn, m_rawConnection);
+		del(conn);
+		finalize();
+		m_rawConnection.close(); // connection not reusable after a protocol upgrade
+	}
+
 	/** Sets the specified cookie value.
 
 		Params:


### PR DESCRIPTION
- added accessors  to the raw streams in the http request and response
- added handling of CONNECT in the proxy request handler
- added handling of websockets upgrade in the proxy request handler

dub test passes
ran tests that websockets proxying works
ran tests that CONNECT proxying works
