### PR TITLE
Add travis testing for GDC 4.9.2 (FE 2.066, yay)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ d:
   - ldc-0.14.0
   - ldc-0.15.1
   - gdc-4.9.0
+  - gdc-4.9.2
 
 before_install:
   - wget http://dist.schmorp.de/libev/Attic/libev-4.19.tar.gz
@@ -27,6 +28,8 @@ matrix:
     - d: ldc-0.15.1
       env: VIBED_DRIVER=libasync
     - d: gdc-4.9.0
+      env: VIBED_DRIVER=libasync
+    - d: gdc-4.9.2
       env: VIBED_DRIVER=libasync
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ d:
   - gdc-4.9.0
   - gdc-4.9.2
 
-before_install:
-  - wget http://dist.schmorp.de/libev/Attic/libev-4.19.tar.gz
-  - tar -xf libev-4.19.tar.gz
-  - (cd libev-4.19 && ./configure && make)
+addons:
+  apt:
+    packages:
+    - libev-dev
 
 env:
   - VIBED_DRIVER=libevent
-  - VIBED_DRIVER=libev-travis
+  - VIBED_DRIVER=libev
   - VIBED_DRIVER=libasync
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ At the moment, it means that the following compilers are supported and tested:
 - DMD 2.066
 - DMD 2.067
 - GDC 4.9.0 (FE: 2.065)
+- GDC 4.9.2 (FE: 2.066)
 - LDC 0.14.0 (FE: 2.065)
 - LDC 0.15.1 (FE: 2.066)
 
@@ -28,7 +29,7 @@ At the moment, it means that the following compilers are supported and tested:
 Installation
 ------------
 
-Instead of explicitly installing vibe.d, it is recommended to use 
+Instead of explicitly installing vibe.d, it is recommended to use
 [DUB](https://github.com/rejectedsoftware/dub) for building vibe.d based
 applications. Once DUB is installed, you can create and run a new project
 using the following shell commands:
@@ -73,7 +74,7 @@ You can then also install DUB using brew:
 (Note: Install brew only if you do not have macports, as they will conflict)
 
 Install DMD using the installer on <http://dlang.org/download.html>.
- 
+
 Optionally, run `./setup-mac.sh` to create a user/group pair for privilege lowering.
 
 

--- a/dub.json
+++ b/dub.json
@@ -49,13 +49,6 @@
 			"versions": ["VibeLibevDriver", "LIBEV4"],
 		},
 		{
-			"name": "libev-travis",
-			"dependencies": {"libev": "~>5.0.0+4.04"},
-			"platforms": ["posix"],
-			"versions": ["VibeLibevDriver", "LIBEV4"],
-			"lflags": ["-Llibev-4.19/.libs/", "-rpath=libev-4.19/.libs/"],
-		},
-		{
 			"name": "win32",
 			"platforms": ["windows"],
 			"versions": ["VibeWin32Driver"],


### PR DESCRIPTION
I tried to include libasync, but: https://travis-ci.org/Geod24/vibe.d/jobs/66281101 (FYI @ibuclaw ).
Also, while searching if GDC 4.9.2 was supported, I stumbled accross https://github.com/travis-ci/apt-package-whitelist/ , so I took the opportunity to remove the old hack for libev.