### PR TITLE
Add callback for SMTPConnectionType.startTLS to vibe.mail.smtp.sendEmail

### DIFF
--- a/source/vibe/mail/smtp.d
+++ b/source/vibe/mail/smtp.d
@@ -168,6 +168,7 @@ void sendMail(SMTPClientSettings settings, Mail mail)
 		expectStatus(conn, SMTPStatus.serviceReady, "STARTTLS");
 		auto ctx = createTLSContext(TLSContextKind.client, settings.tlsVersion);
 		ctx.peerValidationMode = settings.tlsValidationMode;
+		if (settings.tlsContextSetup) settings.tlsContextSetup(ctx);
 		conn = createTLSStream(raw_conn, ctx, TLSStreamState.connecting, settings.host, raw_conn.remoteAddress);
 		greet();
 	}


### PR DESCRIPTION
Callback is missing for startTLS - just a one line change