### PR TITLE
Avoid involuntary DDoS when computer goes to sleep

### DIFF
--- a/source/vibe/core/drivers/timerqueue.d
+++ b/source/vibe/core/drivers/timerqueue.d
@@ -92,7 +92,7 @@ struct TimerQueue(DATA, long TIMER_RESOLUTION = 10_000) {
 			if (!pt || !pt.pending || pt.timeout != tm.timeout) continue;
 
 			if (pt.repeatDuration > 0) {
-				pt.timeout += pt.repeatDuration;
+				pt.timeout = Clock.currStdTime() + pt.repeatDuration;
 				scheduleTimer(pt.timeout, tm.id);
 			} else pt.pending = false;
 


### PR DESCRIPTION
If a periodic timer is set to check on a remote resource, assuming this is in a software on millions of computers, a DDoS would occur when the computer wakes up from sleep/hibernate.