### PR TITLE
Fix range violation when writing to access log

### DIFF
--- a/source/vibe/http/log.d
+++ b/source/vibe/http/log.d
@@ -24,7 +24,7 @@ class HTTPLogger {
 		string m_format;
 		const(HTTPServerSettings) m_settings;
 		InterruptibleTaskMutex m_mutex;
-		FixedAppender!(const(char)[], 2048) m_lineAppender;
+		Appender!(char[]) m_lineAppender;
 	}
 
 	this(in HTTPServerSettings settings, string format)
@@ -32,6 +32,7 @@ class HTTPLogger {
 		m_format = format;
 		m_settings = settings;
 		m_mutex = new InterruptibleTaskMutex;
+		m_lineAppender.reserve(2048);
 	}
 
 	void close() {}
@@ -39,7 +40,7 @@ class HTTPLogger {
 	final void log(scope HTTPServerRequest req, scope HTTPServerResponse res)
 	{
 		m_mutex.performLocked!({
-			m_lineAppender.reset();
+			m_lineAppender.clear();
 			formatApacheLog(m_lineAppender, m_format, req, res, m_settings);
 			writeLine(m_lineAppender.data);
 		});


### PR DESCRIPTION
When the requested URL is > ~2000 bytes the server crashes and the process hangs forever using 100% CPU on Linux. Easily exploitable by malicious users.