### PR TITLE
[REST] Fix URL concatenation in the client to avoid double slashes

### DIFF
--- a/source/vibe/web/rest.d
+++ b/source/vibe/web/rest.d
@@ -372,10 +372,14 @@ class RestInterfaceClient(I) : I
 
 			if (name.length)
 			{
-				string sep = "";
-				if (name[0] != '/' && (!url.pathString.length || url.pathString[0] != '/'))
-					sep = "/";
-				url.pathString = url.pathString ~ sep ~ name;
+				if (url.pathString.length && url.pathString[$ - 1] == '/'
+					&& name[0] == '/')
+					url.pathString = url.pathString ~ name[1 .. $];
+				else if (url.pathString.length && url.pathString[$ - 1] == '/'
+						 || name[0] == '/')
+					url.pathString = url.pathString ~ name;
+				else
+					url.pathString = url.pathString ~ '/' ~ name;
 			}
 
 			if (query.length) url.queryString = query;


### PR DESCRIPTION
This:
```D
@path("/")
interface RootInterface {
    Data get();
}

        auto r = new GithubAPI(agent, "https://api.github.com");
```

Would produce the following (Note the 2 slashes):
`REST call: GET https://api.github.com// -> 404, {"documentation_url":"https://developer.github.com/v3","message":"Not Found"}`

The URL concatenation part was a little too sharp for it's own good, so I simplified it in 3 branches.