### PR TITLE
Libasync FileStream must createTrunc earlier

### DIFF
--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -426,9 +426,20 @@ final class LibasyncFileStream : FileStream {
 
 	this(Path path, FileMode mode)
 	{
-		import std.file : getSize;
+		import std.file : getSize,exists;
 		if (mode != FileMode.createTrunc)
 			m_size = getSize(path.toNativeString());
+		else {
+			auto path_str = path.toNativeString();
+			if (!exists(path_str))
+			{ // touch
+				import std.c.stdio;
+				import std.string : toStringz;
+				FILE * f = fopen(path_str.toStringz, "w\0".ptr);
+				fclose(f);
+				m_truncated = true;
+			}
+		} 
 		m_path = path;
 		m_mode = mode;
 

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -435,7 +435,7 @@ final class LibasyncFileStream : FileStream {
 			{ // touch
 				import std.c.stdio;
 				import std.string : toStringz;
-				FILE * f = fopen(path_str.toStringz, "w\0".ptr);
+				FILE * f = fopen(path_str.toStringz, "w");
 				fclose(f);
 				m_truncated = true;
 			}


### PR DESCRIPTION
When no data is to be written/read, createTrunc must still create the file to avoid further file operations to fail.