### PR TITLE
Added basic support for multi-part form uploads in HTTPClient

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -598,6 +598,14 @@ final class HTTPClientRequest : HTTPRequest {
 		bodyWriter.write(data);
 		finalize();
 	}
+	/// ditto
+	void writeBody(MultiPartPart linked_parts) 
+	{
+		headers["Content-Length"] = linked_parts.size.to!string;
+		linked_parts.read(bodyWriter);
+		finalize();
+	}
+
 
 	/**
 		Writes the response body as JSON data.


### PR DESCRIPTION
This still needs a test, but the logic should be right. These two objects (file, memory) will cover 99% of what's usually needed in multi-part form uploads. The alternative to using these is a lot of boilerplate and some specialized low-level protocol knowledge.