### PR TITLE
Fix peek in libasync

### DIFF
--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -482,13 +482,7 @@ final class LibasyncFileStream : FileStream {
 
 	const(ubyte)[] peek()
 	{
-		assert(this.readable); 
-		auto sz = m_size - m_offset;
-		if (sz == 0) return null;
-		auto ub = new ubyte[cast(size_t)sz];
-		read(ub);
-		m_offset -= ub.length;
-		return ub;
+		return null;
 	}
 
 	void read(ubyte[] dst)

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -482,7 +482,8 @@ final class LibasyncFileStream : FileStream {
 
 	const(ubyte)[] peek()
 	{
-		auto sz = leastSize;
+		assert(this.readable); 
+		auto sz = m_size - m_offset;
 		if (sz == 0) return null;
 		auto ub = new ubyte[cast(size_t)sz];
 		read(ub);

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -482,10 +482,11 @@ final class LibasyncFileStream : FileStream {
 
 	const(ubyte)[] peek()
 	{
-		auto sz = min(1,leastSize);
-		auto ub = new ubyte[min(1, cast(size_t)leastSize)];
+		auto sz = leastSize;
+		if (sz == 0) return null;
+		auto ub = new ubyte[cast(size_t)sz];
 		read(ub);
-		m_offset -= sz;
+		m_offset -= ub.length;
 		return ub;
 	}
 
@@ -562,7 +563,8 @@ final class LibasyncFileStream : FileStream {
 
 	void finalize()
 	{
-		flush();
+		if (this.writable)
+			flush();
 	}
 
 	void release()


### PR DESCRIPTION
The peek function returned at most 1 byte due to a logical error. This also fixes an assertion failure when finalizing a read-only stream (not sure if it should fail)