### PR TITLE
enforce JSON string to contain non-whitespace characters

### DIFF
--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -1155,6 +1155,8 @@ unittest {
 }
 
 unittest {
+	try parseJsonString(" \t\n ");
+	catch (Exception e) assert(e.msg.endsWith("JSON string contains only whitespaces."));
 	try parseJsonString(`{"a": 1`);
 	catch (Exception e) assert(e.msg.endsWith("Missing '}' before EOF."));
 	try parseJsonString(`{"a": 1 x`);

--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -1031,6 +1031,8 @@ Json parseJson(R)(ref R range, int* line = null, string filename = null)
 
 	skipWhitespace(range, line);
 
+	enforceJson(!range.empty, "JSON string contains only whitespaces.", filename, 0);
+
 	version(JsonLineNumbers) {
 		import vibe.core.log;
 		int curline = line ? *line : 0;


### PR DESCRIPTION
When `parseJsonString` receives a string which consists of only whitespace characters, it tries to read the front of empty string at [line 1040 in original code](https://github.com/rejectedsoftware/vibe.d/blob/38784138ad8cc8f442bd0e76a1b740040ff33fe5/source/vibe/data/json.d#L1040).
Then it throws `AssertError` which is not an `Exception`.
So I fixed it by enforcing string to be not empty before taking front of it.