### PR TITLE
Add struct type injection to vibe.web.web

### DIFF
--- a/source/vibe/web/web.d
+++ b/source/vibe/web/web.d
@@ -611,6 +611,8 @@ private void handleRequest(string M, alias overload, C, ERROR...)(HTTPServerRequ
 				else static if (!isNullable!PT) enforceHTTP(false, HTTPStatus.badRequest, "Missing request parameter for "~param_names[i]);
 			} else static if (is(PT == bool)) {
 				params[i] = param_names[i] in req.form || param_names[i] in req.query;
+			} else static if (is(PT == struct) && __traits(compiles, { PT(req, res); }())) {
+				params[i] = PT(req, res);
 			} else {
 				static if (!is(default_values[i] == void)) {
 					if (!readFormParamRec(req, params[i], param_names[i], false))


### PR DESCRIPTION
I haven't tested this but I think it's more intuitive than UDAs so I'm suggesting it here.

It would also be nice to scan the class for TaskLocal!(struct) with a __ctor(req, res), and do the type injection at that level as well.

This would allow me to write more objective deserialization types, enforcemed types or authentication types in general and avoid writing @before UDAs and contextual handlers for them.