### PR TITLE
TimerQueue assertion failure in GC Destructors

### DIFF
--- a/source/vibe/core/drivers/timerqueue.d
+++ b/source/vibe/core/drivers/timerqueue.d
@@ -69,9 +69,9 @@ struct TimerQueue(DATA, long TIMER_RESOLUTION = 10_000) {
 
 	ref inout(DATA) getUserData(size_t timer_id) inout { return m_timers[timer_id].data; }
 
-	bool isPending(size_t timer_id) const { return m_timers[timer_id].pending; }
+	bool isPending(size_t timer_id) const { return m_timers.length > 0 && m_timers[timer_id].pending; }
 
-	bool isPeriodic(size_t timer_id) const { return m_timers[timer_id].repeatDuration > 0; }
+	bool isPeriodic(size_t timer_id) const { return m_timers.length > 0 && m_timers[timer_id].repeatDuration > 0; }
 
 	SysTime getFirstTimeout()
 	{


### PR DESCRIPTION
Make sure the timers don't fail assertion if the GC destroys the queue before the timers are descheduled by a destructor on the GC.