### PR TITLE
http/2 : Avoid returning null streams at all costs

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -1257,7 +1257,13 @@ final class HTTPClientResponse : HTTPResponse {
 	*/
 	@property InputStream bodyReader()
 	{	
-		if (m_finalized) return null;
+		if (m_finalized) {
+			import vibe.stream.memory;
+			static MemoryStream empty_memory_stream;
+			if (!empty_memory_stream)
+				empty_memory_stream = new MemoryStream(null, false, 0);
+			return cast(InputStream)empty_memory_stream;
+		}
 		
 		if( m_bodyReader ) { 
 			logTrace("Returning bodyreader: http2=%s", isHTTP2);


### PR DESCRIPTION
This is a fix for the client. Returning null prevents reading if the stream is empty during a stream operation