### PR TITLE
fixed: calling getLastError against mongos (router) won't return conn…

### DIFF
--- a/source/vibe/db/mongo/connection.d
+++ b/source/vibe/db/mongo/connection.d
@@ -262,7 +262,7 @@ final class MongoConnection {
 					ret = MongoErrorDescription(
 						error.err.opt!string(""),
 						error.code.opt!int(-1),
-						error.connectionId.get!int(),
+						error.connectionId.opt!int(-1),
 						error.n.get!int(),
 						error.ok.get!double()
 					);


### PR DESCRIPTION
When getLastError is called against **mongos (sharding router)** instead of mongodb instance, the returned JSON won't contains **connectionId** field, and vibe.d's mongo driver will throw an exception.

Example response of getLastError against mongos:
```
mongos> db.runCommand("getlasterror")
{
        "err" : "E11000 duplicate key error index: test.test.user.$_id_ dup key: { : 1.0 }",
        "code" : 11000,
        "n" : 0,
        "singleShard" : "db0:30001",
        "ok" : 1
}
```

For more information about mongos,
please check https://docs.mongodb.org/v3.0/reference/program/mongos/