### PR TITLE
cmpxchg16b instruction needs 16byte aligned data.

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1325,7 +1325,7 @@ private {
 	// accessed for every request, needs to be kept thread-safe by only atomically assigning new
 	// arrays (COW). shared immutable(HTTPServerContext)[] would be the right candidate here, but
 	// is impractical due to type system limitations.
-	shared HTTPServerContext[] g_contexts;
+	align(16) shared HTTPServerContext[] g_contexts;
 
 	HTTPServerContext[] getContexts()
 	{


### PR DESCRIPTION
Starting with DMD 2.067.1, the new atomicLoad() and atomicStore() functions are used.
At the core they use cmpxchg16b instruction which needs proper aligned data.

The shared HTTPServerContext[] is not properly aligned and causes a segmentation fault
with the upcoming LDC 0.16.0.

This PR adds align(16) to align the variable.