### PR TITLE
fix and test release build

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1685,28 +1685,20 @@ private string callWithMove(ARGS...)(string func, string args)
 
 private template needsMove(T)
 {
-	private T testCopy()()
+	template isCopyable(T)
 	{
-		T a = void;
-		T b = void;
-		T fun(T x) { T y = x; return y; }
-		b = fun(a);
-		return b;
+		enum isCopyable = __traits(compiles, (T a) { return a; });
 	}
 
-	private void testMove()()
+	template isMoveable(T)
 	{
-		T a = void;
-		void test(T) {}
-		test(a.move);
+		enum isMoveable = __traits(compiles, (T a) { return a.move; });
 	}
 
-	static if (is(typeof(testCopy!()()) == T)) enum needsMove = false;
-	else {
-		enum needsMove = true;
-		void test() { testMove!()(); }
-		static assert(is(typeof(testMove!()())), "Non-copyable type "~T.stringof~" must be movable with a .move property."~ typeof(testMove!()()));
-	}
+	enum needsMove = !isCopyable!T;
+
+	static assert(isCopyable!T || isMoveable!T,
+				  "Non-copyable type "~T.stringof~" must be movable with a .move property.");
 }
 
 unittest {

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -2,6 +2,7 @@
 
 set -e -o pipefail
 
+dub build -b release --compiler=$DC --config=${VIBED_DRIVER=libevent}
 dub test --compiler=$DC --config=${VIBED_DRIVER=libevent}
 
 if [ ${RUN_EXAMPLE} -eq 1 ]; then


### PR DESCRIPTION
- was complaining about `a` being used before initialized
- also failed with 2.068.1 b/c of linkage error