### PR TITLE
make logged url clickable in terminal by adding protocol

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1375,7 +1375,8 @@ private void listenHTTPPlain(HTTPServerSettings settings)
 			auto ret = listenTCP(listen_info.bindPort, (TCPConnection conn) {
 					handleHTTPConnection(conn, listen_info);
 				}, listen_info.bindAddress, dist ? TCPListenOptions.distribute : TCPListenOptions.defaults);
-			logInfo("Listening for HTTP%s requests on %s:%s", listen_info.tlsContext ? "S" : "", listen_info.bindAddress, listen_info.bindPort);
+			auto proto = listen_info.tlsContext ? "https" : "http";
+			logInfo("Listening for requests on %s://%s:%s", proto, listen_info.bindAddress, listen_info.bindPort);
 			return ret;
 		} catch( Exception e ) {
 			logWarn("Failed to listen on %s:%s", listen_info.bindAddress, listen_info.bindPort);


### PR DESCRIPTION
at least os x's terminal supports clickable urls, so with this you can directly click.