### PR TITLE
REST collections

### DIFF
--- a/examples/rest-collections/dub.json
+++ b/examples/rest-collections/dub.json
@@ -1,0 +1,8 @@
+{
+    "name": "rest-collections-example",
+    "description": "Example project demonstrating the use of collections in REST interfaces.",
+    "dependencies": {
+        "vibe-d": {"path": "../../"}
+    },
+    "versions": ["VibeDefaultMain"]
+}

--- a/examples/rest-collections/source/api.d
+++ b/examples/rest-collections/source/api.d
@@ -1,0 +1,51 @@
+/// Defines the REST API
+module api;
+
+import vibe.web.rest;
+
+interface ForumAPI {
+	// base path /threads/
+	Collection!ThreadAPI threads();
+}
+
+interface ThreadAPI {
+	// define the index parameters used to identify the collection items
+	struct CollectionIndices {
+		string _thread_name;
+	}
+
+	// base path /threads/:thread_number/posts/
+	Collection!PostAPI posts(string _thread_name);
+
+	// POST /threads/
+	// Posts a new thread
+	void post(string name, string message);
+
+	// GET /threads/
+	// Returns a list of all thread names
+	string[] get();
+}
+
+interface PostAPI {
+	// define the index parameters used to identify the collection items
+	struct CollectionIndices {
+		string _thread_name;
+		int _post_index;
+	}
+
+	// POST /threads/:thread_number/posts/
+	// Posts a new thread reply
+	void post(string _thread_name, string message);
+
+	// GET /threads/:thread_name/
+	// Returns the number of posts in a thread
+	int getLength(string _thread_name);
+
+	// GET /threads/:thread_number/posts/:post_id
+	// Returns a specific message
+	string getMessage(string _thread_name, int _post_index);
+
+	// GET /threads/:thread_number/posts/
+	// Returns all messages of a particular thread
+	string[] get(string _thread_name);
+}

--- a/examples/rest-collections/source/app.d
+++ b/examples/rest-collections/source/app.d
@@ -1,0 +1,112 @@
+module app;
+
+import api;
+
+import vibe.core.core;
+import vibe.core.log;
+import vibe.http.router;
+import vibe.http.server;
+import vibe.web.rest;
+
+
+class ForumData {
+	// maps thread ID to a list of messages
+	string[][string] threads;
+}
+
+class LocalForumAPI : ForumAPI {
+	ForumData m_data;
+	LocalThreadAPI m_threads;
+
+	this()
+	{
+		m_data = new ForumData;
+		m_threads = new LocalThreadAPI(m_data);
+	}
+
+	Collection!ThreadAPI threads() { return Collection!ThreadAPI(m_threads); }
+}
+
+class LocalThreadAPI : ThreadAPI {
+	private {
+		ForumData m_data;
+		LocalPostAPI m_posts;
+	}
+
+	this(ForumData data)
+	{
+		m_data = data;
+		m_posts = new LocalPostAPI(data);
+	}
+
+	Collection!PostAPI posts(string _thread_name) { return Collection!PostAPI(m_posts, _thread_name); }
+
+	void post(string name, string message)
+	{
+		m_data.threads[name] = [message];
+	}
+
+	string[] get()
+	{
+		return m_data.threads.keys;
+	}
+}
+
+class LocalPostAPI : PostAPI {
+	private {
+		ForumData m_data;
+	}
+
+	this(ForumData data)
+	{
+		m_data = data;
+	}
+	
+	void post(string _thread_name, string message)
+	{
+		m_data.threads[_thread_name] ~= message;
+	}
+
+	int getLength(string _thread_name)
+	{
+		return cast(int)m_data.threads[_thread_name].length;
+	}
+
+	string getMessage(string _thread_name, int _post_index)
+	{
+		return m_data.threads[_thread_name][_post_index];
+	}
+
+	string[] get(string _thread_name)
+	{
+		return m_data.threads[_thread_name];
+	}
+}
+
+shared static this()
+{
+	auto router = new URLRouter;
+	router.registerRestInterface(new LocalForumAPI);
+
+	auto settings = new HTTPServerSettings;
+	settings.bindAddresses = ["127.0.0.1"];
+	settings.port = 8080;
+	listenHTTP(settings, router);
+
+	runTask({
+		auto api = new RestInterfaceClient!ForumAPI("http://127.0.0.1:8080/");
+		logInfo("Current number of threads: %s", api.threads.get().length);
+		logInfo("Posting a topic...");
+		api.threads.post("RESTful services", "Hi, just wanted to post something!");
+		logInfo("Posting a reply...");
+		api.threads["RESTful services"].posts.post("Okay, but what do you actually want to say?");
+		logInfo("New list of threads:");
+		foreach (th; api.threads.get) {
+			import std.array : replicate;
+			logInfo("\n%s\n%s", th, "=".replicate(th.length));
+			foreach (m; api.threads[th].posts.get)
+				logInfo("%s\n---", m);
+		}
+		logInfo("Leaving REST server running. Hit Ctrl+C to exit.");
+	});
+}

--- a/source/vibe/web/internal/rest/common.d
+++ b/source/vibe/web/internal/rest/common.d
@@ -323,8 +323,8 @@ import vibe.web.rest;
 	private template GetSubInterfaceFunctions() {
 		template Impl(size_t idx) {
 			static if (idx < AllMethods.length) {
-				alias R = ReturnType!(AllMethods[idx]);
-				static if (is(R == interface)) {
+				alias SI = SubInterfaceType!(AllMethods[idx]);
+				static if (!is(SI == void)) {
 					alias Impl = TypeTuple!(AllMethods[idx], Impl!(idx+1));
 				} else {
 					alias Impl = Impl!(idx+1);
@@ -337,9 +337,9 @@ import vibe.web.rest;
 	private template GetSubInterfaceTypes() {
 		template Impl(size_t idx) {
 			static if (idx < AllMethods.length) {
-				alias R = ReturnType!(FunctionTypeOf!(AllMethods[idx]));
-				static if (is(R == interface)) {
-					alias Impl = TypeTuple!(R, Impl!(idx+1));
+				alias SI = SubInterfaceType!(AllMethods[idx]);
+				static if (!is(SI == void)) {
+					alias Impl = TypeTuple!(SI, Impl!(idx+1));
 				} else {
 					alias Impl = Impl!(idx+1);
 				}
@@ -352,7 +352,8 @@ import vibe.web.rest;
 		template Impl(size_t idx) {
 			static if (idx < AllMethods.length) {
 				alias F = AllMethods[idx];
-				static if (!is(ReturnType!(FunctionTypeOf!F) == interface))
+				alias SI = SubInterfaceType!F;
+				static if (is(SI == void))
 					alias Impl = TypeTuple!(F, Impl!(idx+1));
 				else alias Impl = Impl!(idx+1);
 			} else alias Impl = TypeTuple!();
@@ -428,6 +429,14 @@ enum ParameterKind {
 
 struct SubInterface {
 	RestInterfaceSettings settings;
+}
+
+template SubInterfaceType(alias F) {
+	import std.traits : ReturnType, isInstanceOf;
+	alias RT = ReturnType!F;
+	static if (is(RT == interface)) alias SubInterfaceType = RT;
+	else static if (isInstanceOf!(Collection, RT)) alias SubInterfaceType = RT.Interface;
+	else alias SubInterfaceType = void;
 }
 
 private bool extractPathParts(ref PathPart[] parts, string pattern)

--- a/tests/restcollections/dub.json
+++ b/tests/restcollections/dub.json
@@ -1,0 +1,8 @@
+{
+    "name": "tests",
+    "description": "High level REST client test for vibe.d",
+    "dependencies": {
+        "vibe-d": {"version": "~master", "path": "../../"}
+    },
+    "versions": ["VibeCustomMain"]
+}

--- a/tests/restcollections/source/app.d
+++ b/tests/restcollections/source/app.d
@@ -92,7 +92,7 @@ void runTest()
 	listenHTTP(settings, router);
 
 	auto api = new RestInterfaceClient!API("http://127.0.0.1:8000/");
-	//assert(api.items["foo"].subItems.length == 2);
+	assert(api.items["foo"].subItems.length == 2);
 	assert(api.items["foo"].subItems[0].name == "hello");
 	assert(api.items["foo"].subItems[1].name == "world");
 	exitEventLoop(true);

--- a/tests/restcollections/source/app.d
+++ b/tests/restcollections/source/app.d
@@ -7,22 +7,24 @@ interface API {
 }
 
 interface ItemAPI {
-	alias ItemID = string;
+	struct CollectionIndices {
+		string _item;
+	}
 
-	@path(":item/sub_items")
 	Collection!SubItemAPI subItems(string _item);
+
 	ItemManagerAPI manager();
-
-
 }
 
 interface SubItemAPI {
-	import std.typetuple;
-	alias ItemID = TypeTuple!(string, int);
+	struct CollectionIndices {
+		string _item;
+		int _index;
+	}
 
 	@property int length(string _item);
 
-	@method(HTTPMethod.GET) @path(":index/name")
+	@method(HTTPMethod.GET)
 	string name(string _item, int _index);
 }
 

--- a/tests/restcollections/source/app.d
+++ b/tests/restcollections/source/app.d
@@ -9,7 +9,8 @@ interface API {
 interface ItemAPI {
 	alias ItemID = string;
 
-	Collection!SubItemAPI subItems(string id);
+	@path(":item/sub_items")
+	Collection!SubItemAPI subItems(string _item);
 	ItemManagerAPI manager();
 
 
@@ -19,10 +20,10 @@ interface SubItemAPI {
 	import std.typetuple;
 	alias ItemID = TypeTuple!(string, int);
 
-	@property int length(string item);
+	@property int length(string _item);
 
-	@method(HTTPMethod.GET)
-	string name(string item, int index);
+	@method(HTTPMethod.GET) @path(":index/name")
+	string name(string _item, int _index);
 }
 
 interface ItemManagerAPI {
@@ -61,9 +62,9 @@ class LocalSubItemAPI : SubItemAPI {
 		m_manager = manager;
 	}
 	
-	@property int length(string item) { return cast(int)m_manager.items[item].length; }
+	@property int length(string _item) { return cast(int)m_manager.items[_item].length; }
 
-	string name(string item, int index) { return m_manager.items[item][index]; }
+	string name(string _item, int _index) { return m_manager.items[_item][_index]; }
 }
 
 class LocalItemManagerAPI : ItemManagerAPI {
@@ -95,6 +96,7 @@ void runTest()
 	assert(api.items["foo"].subItems.length == 2);
 	assert(api.items["foo"].subItems[0].name == "hello");
 	assert(api.items["foo"].subItems[1].name == "world");
+	assert(api.items.manager.databaseURL == "in-memory://");
 	exitEventLoop(true);
 }
 

--- a/tests/restcollections/source/app.d
+++ b/tests/restcollections/source/app.d
@@ -1,0 +1,106 @@
+module app;
+
+import vibe.vibe;
+
+interface API {
+	Collection!ItemAPI items();
+}
+
+interface ItemAPI {
+	alias ItemID = string;
+
+	Collection!SubItemAPI subItems(string id);
+	ItemManagerAPI manager();
+
+
+}
+
+interface SubItemAPI {
+	import std.typetuple;
+	alias ItemID = TypeTuple!(string, int);
+
+	@property int length(string item);
+
+	@method(HTTPMethod.GET)
+	string name(string item, int index);
+}
+
+interface ItemManagerAPI {
+	@property string databaseURL();
+}
+
+
+class LocalAPI : API {
+	LocalItemAPI m_items;
+	this() { m_items = new LocalItemAPI; }
+	Collection!ItemAPI items() { return Collection!ItemAPI(m_items); }
+}
+
+class LocalItemAPI : ItemAPI {
+	private {
+		LocalItemManagerAPI m_manager;
+		LocalSubItemAPI m_subItems;
+	}
+
+	this()
+	{
+		m_manager = new LocalItemManagerAPI;
+		m_subItems = new LocalSubItemAPI(m_manager);
+	}
+
+	Collection!SubItemAPI subItems(string id) { return Collection!SubItemAPI(m_subItems, id); }
+
+	ItemManagerAPI manager() { return m_manager; }
+}
+
+class LocalSubItemAPI : SubItemAPI {
+	private LocalItemManagerAPI m_manager;
+
+	this(LocalItemManagerAPI manager)
+	{
+		m_manager = manager;
+	}
+	
+	@property int length(string item) { return cast(int)m_manager.items[item].length; }
+
+	string name(string item, int index) { return m_manager.items[item][index]; }
+}
+
+class LocalItemManagerAPI : ItemManagerAPI {
+	string[][string] items;
+
+	this()
+	{
+		items = [
+			"foo": ["hello", "world"],
+			"bar": ["this", "is", "a", "test"]
+		];
+	}
+
+	@property string databaseURL() { return "in-memory://"; }
+}
+
+
+void runTest()
+{
+	auto router = new URLRouter;
+	router.registerRestInterface(new LocalAPI);
+
+	auto settings = new HTTPServerSettings;
+	settings.disableDistHost = true;
+	settings.port = 8000;
+	listenHTTP(settings, router);
+
+	auto api = new RestInterfaceClient!API("http://127.0.0.1:8000/");
+	//assert(api.items["foo"].subItems.length == 2);
+	assert(api.items["foo"].subItems[0].name == "hello");
+	assert(api.items["foo"].subItems[1].name == "world");
+	exitEventLoop(true);
+}
+
+int main()
+{
+	setLogLevel(LogLevel.debug_);
+	runTask(toDelegate(&runTest));
+	return runEventLoop();
+}


### PR DESCRIPTION
This PR adds syntactic support for item collections in REST interfaces. It does so in a backwards compatible manner w.r.t interface definition (i.e. existing interfaces stay the same except for defining an additional item key type/name).

Open issues:
 - ~~`@path` annotations currently have to be used manually to get nice URLs (see test project)~~
 - ... don't remember, but there was something else

~~The current `ItemID` `TypeTuple` is going to be replaced by a `struct` that at the same time defines the types and names of the key parameters. The interface generator will then validate all methods to have the right parameters and will automatically generate a proper method path (`":key/method"`).~~

This PR depends on #1266