### PR TITLE
add log output for virtualhosts.

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1411,6 +1411,8 @@ private void listenHTTPPlain(HTTPServerSettings settings)
 		foreach (ctx; contexts) {
 			if (ctx.settings.port != settings.port) continue;
 			if (!ctx.settings.bindAddresses.canFind(lst.bindAddress)) continue;
+      auto proto = lst.tlsContext ? "https" : "http";
+      logInfo("Listening for virtual host requests on %s://%s:%s", proto, settings.hostName, lst.bindPort);
 			/*enforce(ctx.settings.hostName != settings.hostName,
 				"A server with the host name '"~settings.hostName~"' is already "
 				"listening on "~addr~":"~to!string(settings.port)~".");*/


### PR DESCRIPTION
not sure if thats what you referred to @s-ludwig .
currently they are printed for each address family which makes them seem duplicates.
so it should also output the address family, however i was unsure on how to retrieve that.