### PR TITLE
Fix UTF-8 filenames on Windows

### DIFF
--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -45,6 +45,9 @@ private __gshared EventLoop gs_evLoop;
 private EventLoop s_evLoop;
 private DriverCore s_driverCore;
 private shared int s_refCount; // will destroy async threads when 0
+
+version(Windows) extern(C) FILE* _wfopen(const(wchar)* filename, in wchar* mode);
+
 EventLoop getEventLoop() nothrow
 {
 	if (s_evLoop is null)
@@ -465,11 +468,12 @@ final class LibasyncFileStream : FileStream {
 			auto path_str = path.toNativeString();
 			if (!exists(path_str))
 			{ // touch
-				import std.c.stdio;
 				import std.string : toStringz;
-				FILE * f = fopen(path_str.toStringz, "w");
-				fclose(f);
-				m_truncated = true;
+				version(Windows) {
+					import std.utf : toUTF16z;
+					FILE* f = _wfopen(path_str.toUTF16z(), "w");
+				}
+				else FILE * f = fopen(path_str.toStringz, "w");
 			}
 		} 
 		m_path = path;

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -31,6 +31,7 @@ import std.exception;
 import std.string;
 import std.stdio : File;
 import std.typecons;
+import std.c.stdio;
 
 import core.atomic;
 import core.memory;

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -475,6 +475,8 @@ final class LibasyncFileStream : FileStream {
 					FILE* f = _wfopen(path_str.toUTF16z(), "w");
 				}
 				else FILE * f = fopen(path_str.toStringz, "w");
+				fclose(f);
+				m_truncated = true;
 			}
 		} 
 		m_path = path;


### PR DESCRIPTION
This fixes an issue where filenames are created with the wrong encoding and then not found when the UTF-8 encoding applies.