### PR TITLE
Disable SSL3 for TLSVersion.any and upgrade enum with TLS 1.1 and TLS 1.2

### DIFF
--- a/source/vibe/stream/tls.d
+++ b/source/vibe/stream/tls.d
@@ -319,6 +319,8 @@ enum TLSVersion {
 	any, /// Accept SSLv3 or TLSv1.0 and greater
 	ssl3, /// Accept only SSLv3
 	tls1, /// Accept only TLSv1.0
+	tls1_1, /// Accept only TLSv1.1
+	tls1_2, /// Accept only TLSv1.2
 	dtls1, /// Use DTLSv1.0
 
 	ssl23 = any /// Deprecated compatibility alias


### PR DESCRIPTION
What we had discussed in the forum thread. Hopefully it can still make 0.7.26