### PR TITLE
Add HTTPServerRequest.routerRootDir property

### DIFF
--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -251,6 +251,7 @@ final class URLRouter : HTTPServerRequestHandler {
 	/// Handles a HTTP request by dispatching it to the registered route handlers.
 	void handleRequest(HTTPServerRequest req, HTTPServerResponse res)
 	{
+		req.prefix = m_prefix;
 		auto method = req.method;
 
 		auto path = req.path;

--- a/source/vibe/http/router.d
+++ b/source/vibe/http/router.d
@@ -255,16 +255,14 @@ final class URLRouter : HTTPServerRequestHandler {
 
 		string calcBasePath()
 		{
-			import std.string: split;
-			
-			string combined = req.rootDir ~ m_prefix;
-			string result;
-			
-			foreach(part; combined.split("/"))
-				if(part != null)
-					result ~= part ~ "/";
-			
-			return result;
+			import vibe.inet.path;
+			auto prefix = m_prefix;
+			if(prefix == null) prefix = "/";
+			auto path = Path(req.path);
+			if(!path.endsWithSlash) path = path[0 .. $ - 1];
+			auto result = Path(prefix).relativeTo(path);
+			result.endsWithSlash = true;
+			return result.toString;
 		}
 
 		auto path = req.path;

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -543,7 +543,6 @@ final class HTTPServerRequest : HTTPRequest {
 		FixedAppender!(string, 31) m_dateAppender;
 		HTTPServerSettings m_settings;
 		ushort m_port;
-		string m_prefix;
 	}
 
 	public {
@@ -677,13 +676,6 @@ final class HTTPServerRequest : HTTPRequest {
 		{
 			return m_settings;
 		}
-		
-		/** The prefix used by this request's router.
-		*/
-		@property string prefix(string newValue)
-		{
-			return m_prefix = newValue;
-		}
 	}
 
 	this(SysTime time, ushort port)
@@ -748,21 +740,6 @@ final class HTTPServerRequest : HTTPRequest {
 		if (path.length == 0) return "./";
 		auto depth = count(path[1 .. $], '/');
 		return depth == 0 ? "./" : replicate("../", depth);
-	}
-	
-	/** The relative path to the root folder for this request's router.
-		
-		The returned string always ends with a slash.
-	*/
-	@property string routerRootDir() const {
-		string combined = rootDir ~ m_prefix;
-		string result;
-		
-		foreach(part; combined.split("/"))
-			if(part != null)
-				result ~= part ~ "/";
-		
-		return result;
 	}
 }
 

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -543,6 +543,7 @@ final class HTTPServerRequest : HTTPRequest {
 		FixedAppender!(string, 31) m_dateAppender;
 		HTTPServerSettings m_settings;
 		ushort m_port;
+		string m_prefix;
 	}
 
 	public {
@@ -676,6 +677,13 @@ final class HTTPServerRequest : HTTPRequest {
 		{
 			return m_settings;
 		}
+		
+		/** The prefix used by this request's router.
+		*/
+		@property string prefix(string newValue)
+		{
+			return m_prefix = newValue;
+		}
 	}
 
 	this(SysTime time, ushort port)
@@ -740,6 +748,21 @@ final class HTTPServerRequest : HTTPRequest {
 		if (path.length == 0) return "./";
 		auto depth = count(path[1 .. $], '/');
 		return depth == 0 ? "./" : replicate("../", depth);
+	}
+	
+	/** The relative path to the root folder for this request's router.
+		
+		The returned string always ends with a slash.
+	*/
+	@property string routerRootDir() const {
+		string combined = rootDir ~ m_prefix;
+		string result;
+		
+		foreach(part; combined.split("/"))
+			if(part != null)
+				result ~= part ~ "/";
+		
+		return result;
 	}
 }
 


### PR DESCRIPTION
This allows for emitting the correct path when using a URLRouter with a prefix.

Consider the index of a router with prefix "/a/deep/path" which renders:
```jade
a(href="#{req.rootDir}") rootDir
a(href="#{req.routerRootDir}") routerRootDir
```
The following is output:
```html
<a href="../../../">rootDir</a>
<a href="../../../a/deep/path/">routerRootDir</a>
```