### PR TITLE
Dont use OpenSSL SSLv3* methods

### DIFF
--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -391,7 +391,7 @@ final class OpenSSLContext : TLSContext {
 			case TLSContextKind.client:
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_client_method(); options |= SSL_OP_NO_SSLv3; break;
-					case TLSVersion.ssl3: method = SSLv3_client_method(); break;
+					case TLSVersion.ssl3: method = SSLv23_client_method(); options |= SSL_OP_NO_SSLv2|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; break;
 					case TLSVersion.tls1: method = TLSv1_client_method(); break;
 					//case TLSVersion.tls1_1: method = TLSv1_1_client_method(); break;
 					//case TLSVersion.tls1_2: method = TLSv1_2_client_method(); break;
@@ -404,7 +404,7 @@ final class OpenSSLContext : TLSContext {
 			case TLSContextKind.serverSNI:
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_server_method(); options |= SSL_OP_NO_SSLv3; break;
-					case TLSVersion.ssl3: method = SSLv3_server_method(); break;
+					case TLSVersion.ssl3: method = SSLv23_server_method(); options |= SSL_OP_NO_SSLv2|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; break;
 					case TLSVersion.tls1: method = TLSv1_server_method(); break;
 					case TLSVersion.tls1_1: method = SSLv23_server_method(); options |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; break;
 					case TLSVersion.tls1_2: method = SSLv23_server_method(); options |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; break;


### PR DESCRIPTION
They have been disabled on Debian, causing vibe.d to fail to compile.
SSLv3 only connections can still be achieved by passing the appropriate
SSL_OP_NO_* options to OpenSSL

See #1315