### PR TITLE
(Libasync) Destroy the readBuffer on finalize - fixes #1326

### DIFF
--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -1151,7 +1151,7 @@ final class LibasyncTCPConnection : TCPConnection/*, Buffered*/ {
 		scope(exit) releaseWriter();
 
 		// checkConnected();
-
+		destroy(m_readBuffer);
 		onClose(null, false);
 	}
 
@@ -1271,7 +1271,6 @@ final class LibasyncTCPConnection : TCPConnection/*, Buffered*/ {
 	{
 		logTrace("%s", "finalize");
 		flush();
-		destroy(m_readBuffer);
 	}
 
 	void write(InputStream stream, ulong nbytes = 0)

--- a/source/vibe/core/drivers/libasync.d
+++ b/source/vibe/core/drivers/libasync.d
@@ -1271,6 +1271,7 @@ final class LibasyncTCPConnection : TCPConnection/*, Buffered*/ {
 	{
 		logTrace("%s", "finalize");
 		flush();
+		destroy(m_readBuffer);
 	}
 
 	void write(InputStream stream, ulong nbytes = 0)
@@ -1431,7 +1432,6 @@ final class LibasyncTCPConnection : TCPConnection/*, Buffered*/ {
 
 			if (m_tcpImpl.conn && m_tcpImpl.conn.isConnected) {
 				m_tcpImpl.conn.kill(Task.getThis() != Task.init); // close the connection
-				destroy(m_readBuffer);
 				m_tcpImpl.conn = null;
 			}
 		}


### PR DESCRIPTION
Read buffer is currently destroyed when the connection is closed, which prevents the reader from progressing. It has been moved to wait for finalize to be called.

fixes #1326