### PR TITLE
catch non Url Encoded Cookies

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -669,4 +669,9 @@ struct CookieValueMap {
 			}
 		return null;
 	}
+
+	auto length()
+	{ 
+		return m_entries.length;
+	}
 }

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1814,26 +1814,13 @@ private void parseCookies(string str, ref CookieValueMap cookies)
 	while(str.length > 0) {
 		auto idx = str.indexOf('=');
 		enforceBadRequest(idx > 0, "Expected name=value.");
-		string name = str[0 .. idx].strip();
+		string name = str[0 .. idx].strip().sanitize();
 		str = str[idx+1 .. $];
-
 		for (idx = 0; idx < str.length && str[idx] != ';'; idx++) {}
-		string value = str[0 .. idx].strip();
-		try {
-			cookies[name] = value.urlDecode();
-		} catch (Exception e) {
-			cookies[name] = value.sanitize();
-		}
+		string value = str[0 .. idx].strip().sanitize();
+		cookies[name] = value;
 		str = idx < str.length ? str[idx+1 .. $] : null;
 	}
-}
-
-unittest
-{
-	auto cvm = CookieValueMap();
-	string nonUrlEncodedCookie = "test=%%pX;";
-	parseCookies(nonUrlEncodedCookie, cvm);
-	assert(cvm["test"] == "%%pX" );
 }
 
 shared static this()

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1822,7 +1822,6 @@ private void parseCookies(string str, ref CookieValueMap cookies)
 
 unittest 
 {
-
 	auto cvm = CookieValueMap();
 	parseCookies("foo=bar;; baz=zinga; öö=üü   ;   møøse=was=sacked;    onlyval1; =onlyval2; onlykey=", cvm);
 	assert(cvm["foo"] == "bar");
@@ -1832,13 +1831,10 @@ unittest
 	assert( "onlyval1" ! in cvm); //illegal cookie gets ignored
 	assert(cvm["onlykey"] == "");
 	assert(cvm[""] == "onlyval2");
-	
 	assert(cvm.length() == 5);
-
 	cvm = CookieValueMap();
 	parseCookies("", cvm);
 	assert(cvm.length() == 0);
-
 	cvm = CookieValueMap();
 	parseCookies(";;=", cvm);
 	assert(cvm.length() == 1);

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1811,16 +1811,13 @@ private void parseRequestHeader(HTTPServerRequest req, InputStream http_stream, 
 private void parseCookies(string str, ref CookieValueMap cookies)
 {
 	import std.encoding : sanitize;
-	while(str.length > 0) {
-		auto idx = str.indexOf('=');
-		enforceBadRequest(idx > 0, "Expected name=value.");
-		string name = str[0 .. idx].strip().sanitize();
-		str = str[idx+1 .. $];
-		for (idx = 0; idx < str.length && str[idx] != ';'; idx++) {}
-		string value = str[0 .. idx].strip().sanitize();
-		cookies[name] = value;
-		str = idx < str.length ? str[idx+1 .. $] : null;
-	}
+	import std.array : split;
+	import std.string : strip;
+	import std.algorithm.iteration : map, filter, each;
+	str.sanitize.split(";")
+		.map!(kv => kv.strip.split("="))
+		.filter!(kv => kv.length == 2) //ignore illegal cookies
+		.each!(kv => cookies[kv[0]] = kv[1] );
 }
 
 shared static this()

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1820,6 +1820,32 @@ private void parseCookies(string str, ref CookieValueMap cookies)
 		.each!(kv => cookies[kv[0]] = kv[1] );
 }
 
+unittest 
+{
+
+	auto cvm = CookieValueMap();
+	parseCookies("foo=bar;; baz=zinga; öö=üü   ;   møøse=was=sacked;    onlyval1; =onlyval2; onlykey=", cvm);
+	assert(cvm["foo"] == "bar");
+	assert(cvm["baz"] == "zinga");
+	assert(cvm["öö"] == "üü");
+	assert( "møøse" ! in cvm); //illegal cookie gets ignored
+	assert( "onlyval1" ! in cvm); //illegal cookie gets ignored
+	assert(cvm["onlykey"] == "");
+	assert(cvm[""] == "onlyval2");
+	
+	assert(cvm.length() == 5);
+
+	cvm = CookieValueMap();
+	parseCookies("", cvm);
+	assert(cvm.length() == 0);
+
+	cvm = CookieValueMap();
+	parseCookies(";;=", cvm);
+	assert(cvm.length() == 1);
+	assert(cvm[""] == "");
+}
+
+
 shared static this()
 {
 	g_listenersMutex = new Mutex;


### PR DESCRIPTION
catches urlDecode errors and just sanitizes the string;

people in the world wide web send all kind of weird cookies and its uncool if the
request crashes :/

fixes #1228