### PR TITLE
[WIP] Unix sockets integration- Fixes rejectedsoftware/vibe.d#500

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -28,6 +28,7 @@
 	"targetType": "library",
 	"sourcePaths": [],
 	"sourceFiles": ["source/vibe/d.d", "source/vibe/vibe.d"],
+	"excludedSourceFiles-windows": [ "source/vibe/core/unix.d" ],
 
 	"configurations": [
 		{"name": "libevent", "subConfigurations": {"vibe-d:core": "libevent"}},

--- a/source/vibe/core/unix.d
+++ b/source/vibe/core/unix.d
@@ -1,0 +1,498 @@
+/**
+ * Unix socket implementation compatible with the event driver
+ *
+ * Copyright:
+ * © 2015 RejectedSoftware e.K.
+ *
+ * Authors:
+ * Mathias 'Geod24' Lang
+ *
+ * License:
+ * Subject to the terms of the MIT license, as written in
+ * the included LICENSE.txt file.
+ */
+module vibe.core.unix;
+
+import core.time;
+import core.sys.posix.fcntl;
+import core.sys.posix.unistd : close, write;
+import core.sys.posix.sys.socket;
+
+import std.exception : enforce;
+
+import vibe.core.core;
+import vibe.core.driver;
+import vibe.core.log;
+import vibe.core.stream;
+
+
+/*******************************************************************************
+
+	Class to instantiate connections to/via unix sockets.
+
+	This class only support streaming (SOCK_STREAM) sockets.
+
+	Server example:
+	---
+	// Note: Path starting with '\0' are in the abstract linux namespace
+	auto server = UnixSocket.listen("\0test", &handleSingleConnection);
+	// After a while...
+	server.close(); // Stop listening on the socket for new connections
+	---
+
+	Client example:
+	---
+	auto client = UnixSocket.connect("\0test");
+	// The connection is a `vibe.core.stream.ConnectionStream`, see the
+	// documentation for available methods.
+	client.close(); // Close client connection
+	---
+
+*******************************************************************************/
+
+public final class UnixSocket
+{
+	import core.sys.posix.sys.un;
+
+
+	/***************************************************************************
+
+		Convenience alias to the type of delegate to provide to handle
+		a connection.
+
+	***************************************************************************/
+
+	public alias ConnectionHandler = void delegate(UnixStream);
+
+
+	/***************************************************************************
+
+		Starts listening for connection on the given `path`, and call `handler`
+		for each incoming request.
+
+		See `UnixSocket` documentation for a short example.
+
+		Throws:
+			`UnixSocketException` on error
+
+	***************************************************************************/
+
+	public static UnixSocket listen (string path, ConnectionHandler handler)
+	{
+		// Does not need the null termination as it's fixed-length
+		enforce!(UnixSocketException)
+			(path.length <= sockaddr_un.sun_path.length,
+			 "The given path is larger than sockaddr_un.sun_path !");
+
+		// Create socket. We should be able to pass SOCK_STREAM | SOCK_NONBLOCK
+		// as the type but it somehow cause EINVAL to be returned.
+		auto fd = socket(AF_UNIX, SOCK_STREAM, 0);
+		cenforce(fd != -1, "Call to socket failed");
+
+		// Bind to the address
+		sockaddr_un addr;
+		addr.sun_family = AF_UNIX;
+		addr.sun_path[0 .. path.length] = cast(byte[])path;
+		auto ret = bind(fd, cast(sockaddr*) &addr, addr.sizeof);
+		cenforce(ret == 0, "Call to bind failed");
+
+		// Set the non-blocking flag, POSIX way.
+		auto flags = fcntl(fd, F_GETFL, 0);
+		cenforce(flags > -1, "Call to fcntl(F_GETFL) failed");
+		cenforce(0 == fcntl(fd, F_SETFL, flags | O_NONBLOCK),
+				 "Call to fcntl(F_SETFL) failed");
+
+		// Create the file descriptor event
+		auto event = getEventDriver().createFileDescriptorEvent
+			(fd, FileDescriptorEvent.Trigger.read);
+
+		// We're done
+		return new UnixSocket(fd, event).startListener(handler);
+	}
+
+
+	/***************************************************************************
+
+		Start a streaming connection to the given path, as a client.
+
+		See `UnixSocket` documentation for a short example.
+
+		Throws:
+			`UnixSocketException` on error
+
+	***************************************************************************/
+
+	public static UnixStream connect (string path)
+	{
+		// Does not need the null termination as it's fixed-length
+		enforce!(UnixSocketException)
+			(path.length <= sockaddr_un.sun_path.length,
+			 "The given path is larger than sockaddr_un.sun_path !");
+
+		// Create socket. We should be able to pass SOCK_STREAM | SOCK_NONBLOCK
+		// as the type but it somehow cause EINVAL to be returned.
+		auto fd = socket(AF_UNIX, SOCK_STREAM, 0);
+		cenforce(fd != -1, "Call to socket failed");
+
+		// Bind to the address
+		sockaddr_un addr;
+		addr.sun_family = AF_UNIX;
+		addr.sun_path[0 .. path.length] = cast(byte[])path;
+		cenforce(0 == .connect(fd, cast(sockaddr*) &addr, addr.sizeof),
+				 "Call to bind failed");
+
+		// Set the non-blocking flag, POSIX way.
+		auto flags = fcntl(fd, F_GETFL, 0);
+		cenforce(flags > -1, "Call to fcntl failed");
+		cenforce(0 == fcntl(fd, F_SETFL, flags | O_NONBLOCK),
+				 "Call to fcntl failed");
+
+		return new UnixStream(fd);
+	}
+
+
+	/***************************************************************************
+
+		Close a server connection
+
+		Close the listening socket, but does not do any synchronization with
+		any running client task.
+
+	***************************************************************************/
+
+	public void close ()
+	{
+		this.event = null;
+		if (this.file_descriptor != -1)
+		{
+			.close(this.file_descriptor);
+			this.file_descriptor = -1;
+		}
+	}
+
+
+	/***************************************************************************
+
+		Private constructor
+
+		Instance should only ever be created via call to the static functions:
+		`listen` or `connect`.
+
+	***************************************************************************/
+
+	private this (int fd, FileDescriptorEvent ev)
+	{
+		this.file_descriptor = fd;
+		this.event = ev;
+	}
+
+
+	/***************************************************************************
+
+		Start to listen on the binded socket, within a task.
+
+		This starts a new taks which will on the socket in a non-blocking way.
+
+		Returns:
+			`this` for chaining (it's only called from the public `listen`)
+
+	***************************************************************************/
+
+	private UnixSocket startListener (ConnectionHandler handler)
+	{
+		this.listener = runTask(
+			()
+			{
+				cenforce(0 == .listen(this.file_descriptor, 128),
+						 "Call to listen failed");
+
+				while (this.event.wait(Duration.max, FileDescriptorEvent.Trigger.read))
+				{
+					auto fd = accept(this.file_descriptor, null, null);
+					cenforce(fd >= 0, "Call to accept failed");
+
+					runTask(
+						()
+						{
+							handler(new UnixStream(fd));
+						});
+				}
+			});
+		return this;
+	}
+
+
+	private Task listener;
+	private int file_descriptor;
+	private FileDescriptorEvent event;
+}
+
+
+/*******************************************************************************
+
+	Class to represent an unix socket stream connection, either client or
+	server side.
+
+*******************************************************************************/
+
+public final class UnixStream : ConnectionStream
+{
+	/***************************************************************************
+
+		Number of bytes which can be returned by `.peek`, at most.
+
+	***************************************************************************/
+
+	private enum size_t max_peek_size = 4096;
+
+
+	/***************************************************************************
+
+		Private constructor
+
+		Instance should only ever be created by `UnixSocket`'s methods.
+
+	***************************************************************************/
+
+	private this (int fd)
+	{
+		this.file_descriptor = fd;
+		this.event = getEventDriver().createFileDescriptorEvent
+			(fd, FileDescriptorEvent.Trigger.read);
+	}
+
+
+	/***************************************************************************
+
+		Determines the current connection status.
+
+		If connected is false, writing to the connection will trigger an
+		exception. Reading may still succeed as long as there is data left in
+		the input buffer.
+		Use InputStream.empty to determine when to stop reading.
+
+		Returns:
+			Whether or not the connection is active.
+
+	***************************************************************************/
+
+	public override @property bool connected () const
+	{
+		return this.event !is null && this.file_descriptor != -1;
+	}
+
+
+	/***************************************************************************
+
+		Actively closes the connection and frees associated resources.
+
+		Note that close must always be called, even if the remote has already
+		closed the connection. Failure to do so will result in resource and
+		memory leakage.
+
+		Closing a connection implies a call to finalize, so that it doesn't
+		need to be called explicitly (it will be a no-op in that case).
+
+	***************************************************************************/
+
+	public override void close ()
+	{
+		this.event = null;
+		if (this.file_descriptor != -1)
+		{
+			.close(this.file_descriptor);
+			this.file_descriptor = -1;
+		}
+	}
+
+
+	/***************************************************************************
+
+		Sets a timeout until data has to be availabe for read.
+
+		Returns:
+			false on timeout.
+
+	***************************************************************************/
+
+	public override bool waitForData (Duration timeout = Duration.max)
+	{
+		assert(this.connected,
+			   "UnixStream.waitForData called on a closed connection !");
+
+		return this.event.wait(timeout, FileDescriptorEvent.Trigger.read);
+	}
+
+
+	public override bool empty () @property
+	{
+		assert(this.connected,
+			   "UnixStream.empty called on a closed connection !");
+
+		return this.leastSize == 0;
+	}
+
+
+	public override ulong leastSize () @property
+	{
+		assert(this.connected,
+			   "UnixStream.leastSize called on a closed connection !");
+
+		if (this.available)
+		{
+			return this.available;
+		}
+		if (this.waitForData())
+		{
+			this.available = this.peek().length;
+			return this.available;
+		}
+		return 0;
+	}
+
+
+	public override bool dataAvailableForRead () @property
+	{
+		return this.event.wait(0.seconds, FileDescriptorEvent.Trigger.read);
+	}
+
+	public override const(ubyte)[] peek ()
+	{
+		assert(this.connected,
+			   "UnixStream.peek called on a closed connection !");
+
+		import core.stdc.errno;
+		errno = 0;
+		auto size = recv(this.file_descriptor, this.buffer.ptr,
+						 this.buffer.length, MSG_PEEK);
+		if (errno == EWOULDBLOCK || errno == EAGAIN)
+			return null;
+		cenforce(-1 != size, "Call to recv failed");
+		this.available = size;
+		return this.buffer[0 .. size];
+	}
+
+
+	public override void read (ubyte[] dst)
+	{
+		assert(this.connected,
+			   "UnixStream.read called on a closed connection !");
+
+		while (dst.length && this.waitForData(Duration.max))
+		{
+			auto size = recv(this.file_descriptor, dst.ptr, dst.length, 0);
+			cenforce(-1 != size, "Call to recv failed");
+			this.available = 0;
+			dst = dst[size .. $];
+		}
+	}
+
+
+	public override void write (const(ubyte[]) bytes)
+	{
+		assert(this.connected,
+			   "UnixStream.write called on a closed connection !");
+
+		cenforce(bytes.length ==
+				 .write(this.file_descriptor, bytes.ptr, bytes.length),
+			"Call to write failed");
+	}
+
+
+	public override void write (InputStream stream, ulong nbytes = 0LU)
+	{
+		assert(this.connected,
+			   "UnixStream.write called on a closed connection !");
+
+		this.writeDefault(stream, nbytes);
+	}
+
+
+	public override void flush ()
+	{
+		assert(this.connected,
+			   "UnixStream.flush called on a closed connection !");
+
+		assert (0, "FLUSH CALLED");
+	}
+
+	/***************************************************************************
+
+		Flushes and finalizes the stream.
+
+		Finalize has to be called on certain types of streams.
+		No writes are possible after a call to finalize().
+
+	***************************************************************************/
+
+	public override void finalize ()
+	{
+		// No memory to finalize
+	}
+
+	private size_t available;
+	private ubyte[max_peek_size] buffer;
+	private int file_descriptor;
+	private FileDescriptorEvent event;
+}
+
+
+/*******************************************************************************
+
+	Type of Exception thrown by this module
+
+*******************************************************************************/
+
+public class UnixSocketException : Exception
+{
+	@nogc @safe pure nothrow:
+
+    /**
+     * Creates a new instance of Exception. The next parameter is used
+     * internally and should always be $(D null) when passed by user code.
+     * This constructor does not automatically throw the newly-created
+     * Exception; the $(D throw) statement should be used for that purpose.
+     */
+	public this (string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+	{
+		super(msg, file, line, next);
+	}
+
+	/// Ditto
+	public this (string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+	{
+		super(msg, file, line, next);
+	}
+}
+
+
+/*******************************************************************************
+
+	Helper function which mimic enforce but append the `strerror` of `errno`
+	to the error message
+
+	Params:
+
+	Returns:
+
+	Throws:
+		`UnixSocketException` by default
+
+*******************************************************************************/
+
+private T cenforce (T, E : Exception = UnixSocketException)
+	(T ok, lazy const(char)[] message, string file = __FILE__,
+	 ulong line = __LINE__)
+{
+	import core.stdc.errno;
+	import core.stdc.string;
+	import std.format;
+
+	if (!ok)
+	{
+		char* cerror_ptr = strerror(errno);
+		char[] cerror = cerror_ptr[0 .. strlen(cerror_ptr)];
+		throw new E(format("{}: {}", message, cerror), file, line);
+	}
+	return ok;
+}

--- a/source/vibe/core/unix.d
+++ b/source/vibe/core/unix.d
@@ -206,8 +206,9 @@ public final class UnixSocket
 				cenforce(0 == .listen(this.file_descriptor, 128),
 						 "Call to listen failed");
 
-				while (this.event.wait(Duration.max, FileDescriptorEvent.Trigger.read))
+				do
 				{
+					this.event.wait(FileDescriptorEvent.Trigger.read);
 					auto fd = accept(this.file_descriptor, null, null);
 					cenforce(fd >= 0, "Call to accept failed");
 
@@ -216,7 +217,7 @@ public final class UnixSocket
 						{
 							handler(new UnixStream(fd));
 						});
-				}
+				} while (true);
 			});
 		return this;
 	}
@@ -320,7 +321,7 @@ public final class UnixStream : ConnectionStream
 		assert(this.connected,
 			   "UnixStream.waitForData called on a closed connection !");
 
-		return this.event.wait(timeout, FileDescriptorEvent.Trigger.read);
+		return this.event.wait(int.max.seconds, FileDescriptorEvent.Trigger.read);
 	}
 
 

--- a/tests/unixsockets/.gitignore
+++ b/tests/unixsockets/.gitignore
@@ -1,0 +1,6 @@
+.dub
+docs.json
+__dummy.html
+*.o
+*.obj
+unixsockets

--- a/tests/unixsockets/dub.sdl
+++ b/tests/unixsockets/dub.sdl
@@ -1,0 +1,3 @@
+name "unixsockets"
+dependency "vibe-d" path="../../"
+versions "VibeDefaultMain"

--- a/tests/unixsockets/source/app.d
+++ b/tests/unixsockets/source/app.d
@@ -1,0 +1,92 @@
+import vibe.d;
+
+import std.functional : toDelegate;
+import vibe.core.unix;
+import std.stdio;
+
+static immutable socket_path = "\0unix-socket-test1";
+private UnixSocket listener;
+
+debug=Verbose;
+import std.stdio;
+
+shared static this()
+{
+	listener = UnixSocket.listen(socket_path, toDelegate(&handleConnection));
+	// This isn't required by UnixSocket, but it gives some time for the
+	// server to start (else the connect might be performed before the server
+	// starts to listen).
+    setTimer(1.seconds,
+			 () { client(UnixSocket.connect(socket_path)); });
+}
+
+/// Server part: Handle every incoming connection
+private void handleConnection (UnixStream stream)
+{
+	writefln("[SERVER] New connection received !");
+	ubyte[8] buff;
+	size_t curr_value;
+	assert (stream !is null, "Stream is null");
+	while (curr_value < 32)
+	{
+		/*debug(Verbose)*/ writefln("[SERVER] Reading from stream");
+		stream.read(buff);
+		/*debug(Verbose)*/ writefln("[SERVER] Data read: %s", cast(char[])buff);
+		auto val = to!uint(cast(char[])buff);
+		assert(val == (curr_value + 1),
+			   "Expected " ~ to!string(curr_value + 1)
+			   ~ " not: " ~ cast(char[])buff);
+		curr_value = val;
+		/*debug(Verbose)*/ writefln("[SERVER] Writing to stream: %d", curr_value);
+		stream.write(toBuff8(curr_value,buff));
+	}
+	writefln("[SERVER] Disconnecting");
+	stream.close();
+	listener.close();
+	exitEvLoop();
+}
+
+/// Client part: Send the server numbers from 000_000_01 to 000_000_32 and
+/// expect the same answer.
+private void client (UnixStream stream)
+{
+	ubyte[8] buff;
+	writefln("[CLIENT] Client connected !");
+	foreach (val; 1 .. 33)
+	{
+		debug(Verbose) writefln("[CLIENT] Writing to stream: %d", val);
+		stream.write(toBuff8(val, buff));
+		debug(Verbose) writefln("[CLIENT] Reading from stream...");
+		buff[] = 0;
+		stream.read(buff);
+		debug(Verbose) writefln("[CLIENT] Read: %s", cast(char[])buff);
+		auto ret = to!uint(cast(char[])buff);
+		assert(ret == val,
+			   "Expected " ~ to!string(val) ~ " not: " ~ cast(char[])buff);
+	}
+	writefln("[CLIENT] Disconnecting...");
+	stream.close();
+	exitEvLoop();
+}
+
+/// Since the server and client expect to read 8 bytes...
+ubyte[] toBuff8 (ulong val, ref ubyte[8] buffer)
+{
+	buffer[] = '0';
+	foreach_reverse (ref ubyte c; buffer)
+	{
+		c = (val % 10) + '0';
+		val /= 10;
+	}
+	return buffer;
+}
+
+/// Since the order of disconnection is not deterministic, and we want
+/// both client to disconnect, we resort on this 'hack'
+void exitEvLoop ()
+{
+	static short call = 0;
+	call++;
+	if (call == 2)
+		exitEventLoop();
+}


### PR DESCRIPTION
I had a shot at integrating unix sockets with Vibe.d

This is currently not in a mergeable state, for various reasons:
- You might want to discuss the API - I didn't use any connection pool because the number of sockets is more likely to be low, and it can be revisited / implemented on top if I'm proven wrong;
- I had a couple of issues related to the event driver:
  - rejectesoftware/vibe.d#1334
  - As you can see in the last commit, I switched from using `Duration.max` to `int.max.seconds` because it triggers an `assert` in libevent (see below). Right on point was rejectedsoftware/vibe.d#1326 but I think it was a little too `ConnectionStream`-specific. I would favor merging both `FileDescriptorEvent.wait` overloads, and give a special meaning of 0 => returns `true` immediately without yielding if the fd is readable, `false` otherwise, and `Duration.max` to wait indefinitely. Would that make sense / work ?
- `flush` is not yet implemented / tested;
- Several functions are still undocumented;

```
Task terminated with unhandled exception: Assertion failure
core.exception.AssertError@../../source/vibe/core/drivers/libevent2.d(478): Assertion failure
----------------
??:? _d_assert [0x8571ab]
??:? void vibe.core.drivers.libevent2.__assert(int) [0x81a847]
../../source/vibe/core/drivers/libevent2.d:478 void vibe.core.drivers.libevent2.Libevent2Driver.rescheduleTimerEvent(std.datetime.SysTime) [0x7bc474]
../../source/vibe/core/drivers/libevent2.d:421 void vibe.core.drivers.libevent2.Libevent2Driver.rearmTimer(ulong, core.time.Duration, bool) [0x7bbee6]
../../source/vibe/core/drivers/libevent2.d:823 bool vibe.core.drivers.libevent2.Libevent2FileDescriptorEvent.wait(core.time.Duration, vibe.core.driver.FileDescriptorEvent.Trigger) [0x7bdd1b]
../../source/vibe/core/unix.d:209 _D4vibe4core4unix10UnixSocket13startListenerMFDFC4vibe4core4unix10UnixStreamZvZ9__lambda2MFZv [0x7efa79]
../../source/vibe/core/core.d:486 void vibe.core.core.makeTaskFuncInfo!(void delegate()).makeTaskFuncInfo(ref void delegate()).callDelegate(vibe.core.core.TaskFuncInfo*) [0x7167b5]
../../source/vibe/core/core.d:1005 void vibe.core.core.CoreTask.run() [0x7b75f0]
??:? void core.thread.Fiber.run() [0x8b0add]
??:? fiber_entryPoint [0x8b087f]
??:? [0xffffffff]
Program exited with code 1
dub  16.06s user 1.78s system 95% cpu 18.677 total
```
