### PR TITLE
fallback for non url encoded cookies

### DIFF
--- a/source/vibe/http/common.d
+++ b/source/vibe/http/common.d
@@ -693,10 +693,21 @@ struct CookieValueMap {
 		/// Sets the cookie value, applying the specified encoding.
 		void setValue(string value, .Cookie.Encoding encoding = .Cookie.Encoding.url)
 		{
-			final switch (encoding) {
-				case .Cookie.Encoding.none: this.rawValue = value; break;
-				case .Cookie.Encoding.url: this.rawValue = urlEncode(value); break;
+			import std.encoding : sanitize;
+			final switch (encoding) 
+			{
+				case .Cookie.Encoding.none: this.rawValue = value.sanitize(); break;
+				case .Cookie.Encoding.url: 
+				{
+					try {
+						this.rawValue = urlEncode(value); 
+					} catch (Exception e) {
+						this.rawValue = value.sanitize(); //fallback to raw Encoding
+					}
+					break;
+				}			
 			}
+			
 		}
 	}
 


### PR DESCRIPTION
- sanitizes raw string, they could be illegal utf8
- creates a fallback when cookies are not urlencoded

replaces PR #1336