### PR TITLE
Disable 'Bit 0x20' mixed case option in dns resolve of libevent2 driver to make it working like other drivers

### DIFF
--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -126,6 +126,7 @@ final class Libevent2Driver : EventDriver {
 
 		m_dnsBase = evdns_base_new(m_eventLoop, 1);
 		if( !m_dnsBase ) logError("Failed to initialize DNS lookup.");
+		evdns_base_set_option(m_dnsBase, "randomize-case:", "0");
 
 		string hosts_file;
 		version (Windows) hosts_file = `C:\Windows\System32\drivers\etc\hosts`;


### PR DESCRIPTION
I found that not all DNS servers support the 'Bit 0x20' security mechanism (randomize query names to avoid hacking responses).
Libevent2 enables it by default(all other drivers do not enable it) and sometimes fail on resolveHost(), so it is better to disable it by default to avoid such problems.