### PR TITLE
add setsockopt(SO_REUSEPORT) for listening sockets in libevent2/libev drivers

### DIFF
--- a/source/vibe/core/drivers/libev.d
+++ b/source/vibe/core/drivers/libev.d
@@ -316,6 +316,21 @@ final class LibevDriver : EventDriver {
 			logError("Error enabling socket address reuse on listening socket");
 			return null;
 		}
+		version(Posix){
+			enum{ SO_REUSEPORT = 15 }
+			if( setsockopt(listenfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof) ){
+				do{
+					version(linux){
+						// ignore invalid and not supported errors on linux
+						if( errno == EINVAL || errno == ENOPROTOOPT ){
+							break;
+						}						
+					}
+					logError("Error enabling socket port reuse on listening socket");
+					return null;
+				} while(0);
+			}
+		}
 		if( bind(listenfd, cast(
 sockaddr*)sock_addr, SOCKADDR.sizeof) ){
 			logError("Error binding listening socket");

--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -338,6 +338,20 @@ final class Libevent2Driver : EventDriver {
 		int tmp_reuse = 1;
 		socketEnforce(setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) == 0,
 			"Error enabling socket address reuse on listening socket");
+		version (Posix) {
+			enum { SO_REUSEPORT = 15 }
+			if (setsockopt(listenfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof)) {
+				do {
+					version(linux) {
+						// ignore invalid and not supported errors on linux
+						if (errno == EINVAL || errno == ENOPROTOOPT) {
+							break;
+						}						
+					}
+					socketEnforce(false, "Error enabling socket port reuse on listening socket");
+				} while(0);
+			}
+		}
 		socketEnforce(bind(listenfd, bind_addr.sockAddr, bind_addr.sockAddrLen) == 0,
 			"Error binding listening socket");
 		socketEnforce(listen(listenfd, 128) == 0,


### PR DESCRIPTION
socket option SO_REUSEPORT is introduced on linux 3.9, it is different from SO_REUSEPORT in BSD systems, see man socket(7) for details.

I found that libasync enables it by default but libevent2/libev drivers should set it in vibe.d own drivers.