### PR TITLE
add kernel-level distribution support(SO_REUSEPORT) for linux

### DIFF
--- a/source/vibe/core/drivers/libev.d
+++ b/source/vibe/core/drivers/libev.d
@@ -317,6 +317,7 @@ final class LibevDriver : EventDriver {
 			return null;
 		}
 		version(linux) {
+			import vibe.core.drivers.utils;
 			if (setsockopt(listenfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof)) {
 				// ignore invalid and not supported errors
 				if (errno != EINVAL && errno != ENOPROTOOPT) {

--- a/source/vibe/core/drivers/libev.d
+++ b/source/vibe/core/drivers/libev.d
@@ -316,6 +316,15 @@ final class LibevDriver : EventDriver {
 			logError("Error enabling socket address reuse on listening socket");
 			return null;
 		}
+		version(linux) {
+			if (setsockopt(listenfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof)) {
+				// ignore invalid and not supported errors
+				if (errno != EINVAL && errno != ENOPROTOOPT) {
+					logError("Error enabling socket port reuse on listening socket");
+					return null;
+				}
+			}
+		}
 		if( bind(listenfd, cast(
 sockaddr*)sock_addr, SOCKADDR.sizeof) ){
 			logError("Error binding listening socket");

--- a/source/vibe/core/drivers/libevent2.d
+++ b/source/vibe/core/drivers/libevent2.d
@@ -344,6 +344,15 @@ final class Libevent2Driver : EventDriver {
 		int tmp_reuse = 1;
 		socketEnforce(setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR, &tmp_reuse, tmp_reuse.sizeof) == 0,
 			"Error enabling socket address reuse on listening socket");
+		version (linux) {
+			if (options & TCPListenOptions.reusePort) {
+				if (setsockopt(listenfd, SOL_SOCKET, SO_REUSEPORT, &tmp_reuse, tmp_reuse.sizeof)) {
+					if (errno != EINVAL && errno != ENOPROTOOPT) {
+						socketEnforce(false, "Error enabling socket port reuse on listening socket");
+					}
+				}
+			}
+		}
 		socketEnforce(bind(listenfd, bind_addr.sockAddr, bind_addr.sockAddrLen) == 0,
 			"Error binding listening socket");
 		socketEnforce(listen(listenfd, 128) == 0,

--- a/source/vibe/core/drivers/utils.d
+++ b/source/vibe/core/drivers/utils.d
@@ -43,6 +43,12 @@ version (Windows) {
 	alias SystemSocketException = WSAErrorException;
 } else alias SystemSocketException = ErrnoException;
 
+version (linux) {
+	static if (!is(typeof(SO_REUSEPORT))) {
+		enum { SO_REUSEPORT = 15 }
+	}
+}
+
 T socketEnforce(T)(T value, lazy string msg = null, string file = __FILE__, size_t line = __LINE__)
 {
 	return enforceEx!SystemSocketException(value, msg, file, line);

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -321,11 +321,15 @@ interface UDPConnection {
 */
 enum TCPListenOptions {
 	/// Don't enable any particular option
-	defaults = 0,
+	defaults = reusePort,
 	/// Causes incoming connections to be distributed across the thread pool
 	distribute = 1<<0,
 	/// Disables automatic closing of the connection when the connection callback exits
 	disableAutoClose = 1<<1,
+	/** Enable port reuse on linux kernel version >=3.9, do nothing on other OS
+	    Does not affect libasync driver because it is always enabled by libasync.
+	*/
+	reusePort = 1<<2,
 }
 
 private pure nothrow {

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -321,7 +321,7 @@ interface UDPConnection {
 */
 enum TCPListenOptions {
 	/// Don't enable any particular option
-	defaults = reusePort,
+	defaults = 0,
 	/// Causes incoming connections to be distributed across the thread pool
 	distribute = 1<<0,
 	/// Disables automatic closing of the connection when the connection callback exits

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -347,8 +347,7 @@ enum HTTPServerOption {
 		parseJsonBody |
 		parseMultiPartBody |
 		parseCookies |
-		errorStackTraces |
-		reusePort,
+		errorStackTraces,
 
 	/// deprecated
 	None = none,

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -333,6 +333,8 @@ enum HTTPServerOption {
 		help an attacker to abuse possible security holes.
 	*/
 	errorStackTraces          = 1<<7,
+	/// Enable port reuse in listenTCP()
+	reusePort                 = 1<<8,
 
 	/** The default set of options.
 
@@ -345,7 +347,8 @@ enum HTTPServerOption {
 		parseJsonBody |
 		parseMultiPartBody |
 		parseCookies |
-		errorStackTraces,
+		errorStackTraces |
+		reusePort,
 
 	/// deprecated
 	None = none,
@@ -1412,12 +1415,15 @@ private void listenHTTPPlain(HTTPServerSettings settings)
 {
 	import std.algorithm : canFind;
 
-	static TCPListener doListen(HTTPListenInfo listen_info, bool dist)
+	static TCPListener doListen(HTTPListenInfo listen_info, bool dist, bool reusePort)
 	{
 		try {
+			TCPListenOptions options = TCPListenOptions.defaults;
+			if(dist) options |= TCPListenOptions.distribute; else options &= ~TCPListenOptions.distribute;
+			if(reusePort) options |= TCPListenOptions.reusePort; else options &= ~TCPListenOptions.reusePort;
 			auto ret = listenTCP(listen_info.bindPort, (TCPConnection conn) {
 					handleHTTPConnection(conn, listen_info);
-				}, listen_info.bindAddress, dist ? TCPListenOptions.distribute : TCPListenOptions.defaults);
+				}, listen_info.bindAddress, options);
 			auto proto = listen_info.tlsContext ? "https" : "http";
 			auto urladdr = listen_info.bindAddress;
 			if (urladdr.canFind(':')) urladdr = "["~urladdr~"]";
@@ -1480,7 +1486,7 @@ private void listenHTTPPlain(HTTPServerSettings settings)
 			}
 			if (!found_listener) {
 				auto linfo = new HTTPListenInfo(addr, settings.port, settings.tlsContext);
-				if (auto tcp_lst = doListen(linfo, (settings.options & HTTPServerOption.distribute) != 0)) // DMD BUG 2043
+				if (auto tcp_lst = doListen(linfo, (settings.options & HTTPServerOption.distribute) != 0, (settings.options & HTTPServerOption.reusePort) != 0)) // DMD BUG 2043
 				{
 					linfo.listener = tcp_lst;
 					found_listener = true;


### PR DESCRIPTION
libasync does not have setOption for AsyncTCPListener so I do think it is impossible to support TCPListenOptions.reusePort in libasync driver at present.
Therefore I only add it to libevent/libev drivers.