### PR TITLE
Libevent read buffer

### DIFF
--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -207,7 +207,7 @@ package final class Libevent2TCPConnection : TCPConnection {
 		}
 		acquireReader();
 		scope(exit) releaseReader();
-		fillReadBuffer(true);
+		fillReadBuffer(true, false);
 		return m_readBuffer.length;
 	}
 
@@ -396,6 +396,10 @@ package final class Libevent2TCPConnection : TCPConnection {
 			m_readBuffer.putN(nbytes);
 			if (m_readBuffer.length || !block) break;
 			if (throw_on_fail) checkConnected(false);
+			else if (!m_ctx || !m_ctx.event) return false;
+			else if (m_ctx.state != ConnectionState.open
+				&& evbuffer_get_length(bufferevent_get_input(m_ctx.event)) == 0)
+					return false;
 			if (wait_for_timeout && m_timeout_triggered) return true;
 			m_ctx.core.yieldForEvent();
 		}

--- a/tests/tcp/source/app.d
+++ b/tests/tcp/source/app.d
@@ -120,11 +120,15 @@ void test2()
 		sleep(1.seconds);
 		StopWatch sw;
 		sw.start();
-		assert(conn.waitForData() == true);
-		assert(cast(Duration)sw.peek < 500.msecs); // waitForData should return immediately
-		assert(conn.dataAvailableForRead);
-		assert(conn.readAll() == "test");
-		conn.close();
+		try {
+			assert(conn.waitForData() == true);
+			assert(cast(Duration)sw.peek < 500.msecs); // waitForData should return immediately
+			assert(conn.dataAvailableForRead);
+			assert(conn.readAll() == "test");
+			conn.close();
+		} catch (Exception e) {
+			assert(false, "Failed to read pending data: " ~ e.msg);
+		}
 	}, "127.0.0.1");
 
 	auto conn = connectTCP("127.0.0.1", port+1);


### PR DESCRIPTION
This makes `Libevent2TCPConnection` use a `FixedRingBuffer` based read buffer instead of the one built into libevent, which is considerably slower (~18% slower when tested against a simple HTTP server). Currently, the libevent buffer still exists and removing it requires further work (using an `event*` instead of a `bufferevent*`).