### PR TITLE
Fixed empty and leastSize for OpenSSLStream

### DIFF
--- a/source/vibe/stream/openssl.d
+++ b/source/vibe/stream/openssl.d
@@ -178,13 +178,14 @@ final class OpenSSLStream : TLSStream {
 
 	@property bool empty()
 	{
-		return leastSize() == 0 && m_stream.empty;
+		return leastSize() == 0;
 	}
 
 	@property ulong leastSize()
 	{
-		auto ret = SSL_pending(m_tls);
-		return ret > 0 ? ret : m_stream.empty ? 0 : 1;
+		SSL_peek(m_tls, m_peekBuffer.ptr, 1);
+		checkExceptions();
+		return SSL_pending(m_tls);
 	}
 
 	@property bool dataAvailableForRead()


### PR DESCRIPTION
The previous implementations were sometimes incorrect, because
SSL_pending only returns the current pending bytes without blocking, and
even if the underlying stream has data available, it might not be
application bytes. Using SSL_peek will block until application
bytes are available or the end of stream has been reached.
See http://permalink.gmane.org/gmane.comp.encryption.openssl.user/6536
