### PR TITLE
Fix RedisReply leaving connection in unusable state if an exception o…

### DIFF
--- a/source/vibe/db/redis/redis.d
+++ b/source/vibe/db/redis/redis.d
@@ -1273,6 +1273,7 @@ struct RedisReply(T = ubyte[]) {
 		auto ctx = &m_conn.m_replyContext;
 		assert(!ctx.initialized);
 		ctx.initialized = true;
+		scope (failure) drop();
 
 		auto ln = cast(string)m_conn.conn.readLine();
 


### PR DESCRIPTION
…ccurs during initialization

This is required because if an exception is thrown in a constructor, the
destructor will not be called.