### PR TITLE
Better parsing of host/port

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1555,6 +1555,75 @@ private void handleHTTPConnection(TCPConnection connection, HTTPListenInfo liste
 	logTrace("Done handling connection.");
 }
 
+struct HostPort {
+	string host;
+	ulong port;
+};
+
+HostPort parseHostPort(string s) {
+	HostPort res;
+	const(char)[] arr = s.to!(const(char)[]);
+	enum {
+		BEFORE_BRACKET,
+		IN_BRACKET,
+		AFTER_BRACKET
+	}
+	auto state = BEFORE_BRACKET;
+	ulong bracket, colon, close_bracket;
+	ulong i;
+	void foundit(ulong i) {
+		enforce(i > 1, "Must specify a host before the :");
+		enforce(i + 2 < reqhostarr.length,
+				"Must specify a port after the :");
+		res.host = reqhostarr[0..i].to!string;
+		res.port = reqhostarr[i+1..$].to!ushort;
+	}
+	for(i=0;i<arr.length;++i) {
+		char c = reqhostarr[i];
+		final switch(state) {
+		case BEFORE_BRACKET:
+			switch(c) {
+			case '[':
+				state = IN_BRACKET;
+				continue;
+			case ':':
+				state = AFTER_BRACKET;
+				foundit(i);
+				return res;
+			default:
+				continue;
+			}
+			continue;
+		case IN_BRACKET:
+			if(c==']') {
+				state = AFTER_BRACKET;
+				if(i+1 < arr.length) {
+					enforce(arr[i+1]==':',
+							"Must specify a : after ]");
+					foundit(i);
+					return res;
+				} else {
+					res.host = s;
+					re
+				}
+			}
+			continue;
+		case AFTER_BRACKET:
+			return res;
+		}
+	}
+
+	if(state == BEFORE_BRACKET) {
+		res.host = s;
+	} else {
+		enforce(state != IN_BRACKET,
+				"Unterminated IPv6 address (no closing ])");
+	}
+	return res;
+}
+
+
+
 private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTTPListenInfo listen_info, ref HTTPServerSettings settings, ref bool keep_alive)
 {
 	import std.algorithm : canFind;
@@ -1646,61 +1715,11 @@ private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTT
 		logTrace("Got request header.");
 
 		// find the matching virtual host
-		string reqhost;
-		ushort reqport = 0;
-		enum { BEFORE_BRACKET,
-			   IN_BRACKET,
-			   AFTER_BRACKET
-		} state = BEFORE_BRACKET;
-		ulong bracket, colon, close_bracket;
-		ulong i;
-		const(char)[] reqhostarr = req.host;
-		delegate void foundit(ulong i) {
-			enforce(i > 1, "Must specify a host before the :");
-			enforce(i + 2 < reqhostarr.length,
-					"Must specify a port after the :");
-			reqhost = reqhostarr[0..i];
-			reqport = reqhostarr[i+1..$].to!ulong;
-		}
-		for(i=0;i<reqhostarr.length;++i) {
-			char c = reqhostarr[i];
-			switch(state) {
-			case BEFORE_BRACKET:
-				switch(c) {
-				case '[':
-					state = IN_BRACKET;
-					continue;
-				case ':':
-					state = AFTER_BRACKET;
-					foundit(i);
-					break;
-				}
-			case IN_BRACKET:
-				if(c==']') {
-					state = AFTER_BRACKET;
-					if(i+1 < reqhostarr.length) {
-						enforce(reqhostarr[i+1]==':',
-								"Must specify a : after ]");
-						foundit(i);
-						break;
-					} else {
-						reqhost = req.host;
-						break;
-					}
-				}
-				continue;
-			}
-		}
-		if(state == BEFORE_BRACKET) {
-			reqhost = req.host;
-		} else {
-			enforce(state != IN_BRACKET,
-					"Unterminated IPv6 address (no closing ])");
-		}
+		HostPort hp = parseHostPort(req.host);
 
 		foreach (ctx; getContexts())
-			if (icmp2(ctx.settings.hostName, reqhost) == 0 &&
-				(!reqport || reqport == ctx.settings.port))
+			if (icmp2(ctx.settings.hostName, hp.host) == 0 &&
+				(!hp.port || hp.port == ctx.settings.port))
 			{
 				if (ctx.settings.port != listen_info.bindPort) continue;
 				bool found = false;

--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1573,13 +1573,13 @@ HostPort parseHostPort(string s) {
 	ulong i;
 	void foundit(ulong i) {
 		enforce(i > 1, "Must specify a host before the :");
-		enforce(i + 2 < reqhostarr.length,
+		enforce(i + 2 < arr.length,
 				"Must specify a port after the :");
-		res.host = reqhostarr[0..i].to!string;
-		res.port = reqhostarr[i+1..$].to!ushort;
+		res.host = arr[0..i].to!string;
+		res.port = arr[i+1..$].to!ushort;
 	}
 	for(i=0;i<arr.length;++i) {
-		char c = reqhostarr[i];
+		char c = arr[i];
 		final switch(state) {
 		case BEFORE_BRACKET:
 			switch(c) {
@@ -1593,7 +1593,6 @@ HostPort parseHostPort(string s) {
 			default:
 				continue;
 			}
-			continue;
 		case IN_BRACKET:
 			if(c==']') {
 				state = AFTER_BRACKET;
@@ -1603,8 +1602,7 @@ HostPort parseHostPort(string s) {
 					foundit(i);
 					return res;
 				} else {
-					res.host = s;
-					re
+					res.host = s;					
 				}
 			}
 			continue;
@@ -1622,8 +1620,18 @@ HostPort parseHostPort(string s) {
 	return res;
 }
 
-
-
+unittest {
+	HostPort res = parseHostPort("hostname");
+	assert(res.host == "hostname" && res.port == 0);
+	res = parseHostPort("host:4234");
+	assert(res.host == "host" && res.port == 4234);
+	res = parseHostPort("1.2.3.4:4234");
+	assert(res.host == "1.2.3.4" && res.port == 4234);
+	res = parseHostPort("[12:3::424:3:]:4234");
+	assert(res.host == "[12:3::424:3:]" && res.port == 4234);
+	import std.stdio;
+	stdout.write("Okay yay!\n");
+}
 private bool handleRequest(Stream http_stream, TCPConnection tcp_connection, HTTPListenInfo listen_info, ref HTTPServerSettings settings, ref bool keep_alive)
 {
 	import std.algorithm : canFind;


### PR DESCRIPTION
One nitpick I have with vibe is that it can't parse IPv6 addresses in urls (because of colons between []). The parsing of that stuff was kind of clunky too, using nonspecific array splits and trying to examine those to see if there's a good host/port. So, I rewrote the host/port parser. Now it does IPv6 addresses just fine. Verified it with an app of my own. I haven't tested against a huge comprehensive list of all sorts of possible URLs, but that'd be a task in of itself I think. 

IPv6 addresses can have variable amounts of colons, and numbers between colons are often optional too, which is why those difficult to parse addresses are surrounded by [] in URLs, so all I had to do was search for ].

tl;dr with this patch, if you have an IPv6 address, then http://[1:2::2::33]:45/ should work now.