### PR TITLE
Ensure that RedisReply is properly cleaned up. Fixes #1412.

### DIFF
--- a/tests/redis/source/app.d
+++ b/tests/redis/source/app.d
@@ -7,6 +7,7 @@ import vibe.core.log;
 import vibe.db.redis.redis;
 import core.time;
 import std.algorithm : sort, equal;
+import std.exception : assertThrown;
 
 void runTest()
 {
@@ -121,6 +122,10 @@ void runTest()
 	logInfo("LISTEN Stopped");
 	assert(!sub.isListening);
 	redis.getDatabase(0).publish("SomeChannel", "Messageeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+	assertThrown(redis.getDatabase(0).eval("foo!!!", null));
+	assert(redis.getDatabase(0).get("test1") == "");
+
 	logInfo("Redis Test Succeeded.");
 }
 


### PR DESCRIPTION
Ensures that the reference count is decremented if an exception happens when reading the reply header. Also closes the connection if an unexpected reply format is encountered.

Issue #1412.