### PR TITLE
Fix #1310: dub test fails

### DIFF
--- a/source/vibe/appmain.d
+++ b/source/vibe/appmain.d
@@ -20,6 +20,8 @@
 */
 module vibe.appmain;
 
+version (unittest){}
+else
 version (VibeDefaultMain):
 
 /**


### PR DESCRIPTION
Make sure "VibeDefaultMain" is not set when "version(unittest)"
is set.