### PR TITLE
Fixed StaticRoute working incorrectly with the same headerParam on mu…

### DIFF
--- a/source/vibe/web/internal/rest/common.d
+++ b/source/vibe/web/internal/rest/common.d
@@ -260,7 +260,7 @@ import vibe.web.rest;
 
 				// Comparison template for anySatisfy
 				//template Cmp(WebParamAttribute attr) { enum Cmp = (attr.identifier == ParamNames[i]); }
-				alias CompareParamName = GenCmp!("Loop", i, parameterNames[i]);
+				alias CompareParamName = GenCmp!("Loop"~func.mangleof, i, parameterNames[i]);
 				mixin(CompareParamName.Decl);
 
 				StaticParameter pi;


### PR DESCRIPTION
…ltiple methods in interface

When the same interface had multiple functions all using the same headerParam, the comparator for AnySatisfy was reused from previously-compared functions, resulting in completely incorrect results

Some details in the code below.


Example:
```d
import vibe.d;

interface API
{
	Collection!FooCollection foos();
}

class APIImpl : API
{
	private FooCollection _foos;

	this()
	{
		_foos = new FooCollectionImpl;
	}

	Collection!FooCollection foos()
	{
		return Collection!FooCollection(_foos);
	}
}

enum fooHeader = headerParam("foo", "FooHeader");
interface FooCollection
{
	struct CollectionIndices
	{
		long _id;
	}


// foo is the second param here
	@fooHeader
		string getSomething(long asd, string foo);

// BOTH the second param and the third one will now be headerParams("<fieldname>", "FooHeader")
	@fooHeader
		string get(long _id, int bar, string foo);
}

class FooCollectionImpl : FooCollection
{

	string getSomething(long asd, string foo)
	{
		return foo;
	}

	string get(long _id, int bar, string foo)
	{
		return foo;
	}
}

shared static this()
{
	auto settings = new HTTPServerSettings;
	settings.port = 8080;
	settings.bindAddresses = ["::1", "127.0.0.1"];

	auto router = new URLRouter;
	router.registerRestInterface(new APIImpl);

	listenHTTP(settings, router);
}
```