### PR TITLE
Issue1452 crash for tcp close at shutdown

### DIFF
--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -160,7 +160,7 @@ package final class Libevent2TCPConnection : TCPConnection {
 
 		if (!getThreadLibeventEventLoop()) {
 			import std.stdio;
-			stderr.writefln("Warning: Dangling TCP connection to %s left alive at shutdown. "
+			stderr.writefln("Warning: Attempt to close dangling TCP connection to %s at shutdown. "
 				~ "Please avoid closing connections in GC finalizers.", m_remoteAddress);
 			return;
 		}

--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -158,6 +158,13 @@ package final class Libevent2TCPConnection : TCPConnection {
 		logDebug("TCP close request %s %s", m_ctx !is null, m_ctx ? m_ctx.state : ConnectionState.open);
 		if (!m_ctx || m_ctx.state == ConnectionState.activeClose) return;
 
+		if (!getThreadLibeventEventLoop()) {
+			import std.stdio;
+			stderr.writefln("Warning: Dangling TCP connection to %s left alive at shutdown. "
+				~ "Please avoid closing connections in GC finalizers.", m_remoteAddress);
+			return;
+		}
+
 		// set the closing flag
 		m_ctx.state = ConnectionState.activeClose;
 

--- a/tests/vibe.core.net.1452/dub.sdl
+++ b/tests/vibe.core.net.1452/dub.sdl
@@ -1,0 +1,3 @@
+name "tests"
+description "Invalid memory operation on TCP connection leakage at shutdown"
+dependency "vibe-d:core" path="../../"

--- a/tests/vibe.core.net.1452/source/app.d
+++ b/tests/vibe.core.net.1452/source/app.d
@@ -1,0 +1,23 @@
+import vibe.core.core;
+import vibe.core.net;
+import core.time : msecs;
+
+class C {
+	TCPConnection m_conn;
+
+	this()
+	{
+		m_conn = connectTCP("google.com", 443);
+	}
+
+	~this()
+	{
+		m_conn.close();
+	}
+}
+
+void main()
+{
+	auto c = new C;
+	// let druntime collect c during shutdown
+}


### PR DESCRIPTION
Fixes the `InvalidMemoryOperationError` by avoiding the assertion and instead writing a warning message to the console. Fixes #1452.