### PR TITLE
Improve XHTML support by emitting XHTML/HTML5 compatible line break tags

### DIFF
--- a/source/vibe/textfilter/markdown.d
+++ b/source/vibe/textfilter/markdown.d
@@ -613,8 +613,11 @@ private void writeMarkdownEscaped(R)(ref R dst, string ln, in LinkRef[string] li
 				} else {
 					if (ln.startsWith("<br>")) {
 						// always support line breaks, since we embed them here ourselves!
-						dst.put("<br>");
+						dst.put("<br/>");
 						ln = ln[4 .. $];
+					} else if(ln.startsWith("<br/>")) {
+						dst.put("<br/>");
+						ln = ln[5 .. $];
 					} else {
 						if( settings.flags & MarkdownFlags.noInlineHtml ) dst.put("&lt;");
 						else dst.put(ln[0]);
@@ -1134,7 +1137,7 @@ private struct Link {
 
 @safe unittest { // correct line breaks in restrictive mode
 	auto res = filterMarkdown("hello\nworld", MarkdownFlags.forumDefault);
-	assert(res == "<p>hello<br>world\n</p>\n", res);
+	assert(res == "<p>hello<br/>world\n</p>\n", res);
 }
 
 /*@safe unittest { // code blocks and blockquotes


### PR DESCRIPTION
I recently stumbled upon the Markdown parser and noticed that its output is not XHTML-compatible. This change should improve that, while staying compatible to HTML5 (although not to HTML4).

I adjusted the testcase too, but I didn't manage to actually run the tests (I'm not very used to D-land yet).

Please let me know what you think.