### PR TITLE
special exception for connection errors in libevent

### DIFF
--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -348,7 +348,7 @@ package final class Libevent2TCPConnection : TCPConnection {
 		logTrace("evbuffer_add (fd %d): %d B", m_ctx.socketfd, bytes.length);
 		auto outbuf = bufferevent_get_output(m_ctx.event);
 		if( bufferevent_write(m_ctx.event, cast(char*)bytes.ptr, bytes.length) != 0 )
-			throw new Exception("Failed to write data to buffer");
+			throw new ConnectionException(format("Failed to write data to buffer for peer %s", m_ctx.remote_addr.toString()));
 
 		// wait for the data to be written up the the low watermark
 		while (evbuffer_get_length(outbuf) > 4096) {
@@ -427,10 +427,12 @@ package final class Libevent2TCPConnection : TCPConnection {
 	{
 		enforce(m_ctx !is null, "Operating on closed TCPConnection.");
 		if (m_ctx.event is null) {
+			string peer = m_ctx.remote_addr.toString();
 			cleanup();
-			throw new ConnectionException(format("Connection error while %s TCPConnection.", write ? "writing to" : "reading from"));
+			throw new ConnectionException(
+				format("Connection error while %s TCPConnection. Remote: %s", write ? "writing to" : "reading from", peer));
 		}
-		if (m_ctx.state == ConnectionState.activeClose) throw new ConnectionException("Connection was actively closed.");
+		if (m_ctx.state == ConnectionState.activeClose) throw new ConnectionException(format("Connection with %s was actively closed.", m_ctx.remote_addr.toString()));
 		enforce (!write || m_ctx.state == ConnectionState.open, "Remote hung up while writing to TCPConnection.");
 		if (!write && m_ctx.state == ConnectionState.passiveClose) {
 			auto buf = bufferevent_get_input(m_ctx.event);

--- a/source/vibe/core/drivers/libevent2_tcp.d
+++ b/source/vibe/core/drivers/libevent2_tcp.d
@@ -428,9 +428,9 @@ package final class Libevent2TCPConnection : TCPConnection {
 		enforce(m_ctx !is null, "Operating on closed TCPConnection.");
 		if (m_ctx.event is null) {
 			cleanup();
-			throw new Exception(format("Connection error while %s TCPConnection.", write ? "writing to" : "reading from"));
+			throw new ConnectionException(format("Connection error while %s TCPConnection.", write ? "writing to" : "reading from"));
 		}
-		if (m_ctx.state == ConnectionState.activeClose) throw new Exception("Connection was actively closed.");
+		if (m_ctx.state == ConnectionState.activeClose) throw new ConnectionException("Connection was actively closed.");
 		enforce (!write || m_ctx.state == ConnectionState.open, "Remote hung up while writing to TCPConnection.");
 		if (!write && m_ctx.state == ConnectionState.passiveClose) {
 			auto buf = bufferevent_get_input(m_ctx.event);

--- a/source/vibe/core/drivers/utils.d
+++ b/source/vibe/core/drivers/utils.d
@@ -9,6 +9,17 @@ module vibe.core.drivers.utils;
 
 import std.exception;
 
+/**
+ * Whenever Something goes wrong with the connection
+ */
+class ConnectionException : Exception
+{
+	this(string message, string file = __FILE__, int line = __LINE__, Throwable next = null)
+	{
+		super(message, file, line, next);
+	}
+}
+
 version (Windows) {
 	static if (__VERSION__ >= 2070) {
 		import core.sys.windows.windows;


### PR DESCRIPTION
ideas here:
a) make the errors catchable so it can be ignored or more silently logged
b) add some information about the peer if possible.

*PR is probably not usable as is, but i want to discuss the Idea.*

reason: i see lots of such errors in production (mainly from mobile ios devices):
```
 vibe.core.drivers.utils.ConnectionException@../vibe.d/source/vibe/core/drivers/libevent2_tcp.d(432): Connection error while writing to TCPConnection. Remote: 127.0.0.1:55774
[EF29AF15:EF2B1315 2016.04.06 18:15:51.581 ERR] ----------------
[EF29AF15:EF2B1315 2016.04.06 18:15:51.581 ERR] ../vibe.d/source/vibe/core/drivers/libevent2_tcp.d:432 void vibe.core.drivers.libevent2_tcp.Libevent2TCPConnection.checkConnected(bool) [0x8e45bc]
[EF29AF15:EF2B1315 2016.04.06 18:15:51.581 ERR] ../v
```