### PR TITLE
Add HTTPServerResponse.connected property

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1136,6 +1136,15 @@ final class HTTPServerResponse : HTTPResponse {
 	}
 
 	/**
+		Returns $(D true) if remote peer is still connected and $(D false) when
+		remote peer closed the connection.
+	*/
+	@property bool connected() {
+		if (!m_rawConnection) return false;
+		return m_rawConnection.connected;
+	}
+
+	/**
 		Finalizes the response. This is usually called automatically by the server.
 
 		This method can be called manually after writing the response to force


### PR DESCRIPTION
(Second try, for curiosity of failed travis build.)

Adds to HTTPServerResponse a new property, `bool connected()`; which should return `true` in case remote peer still holding the connection and `false` ever since connection was severed, might be useful in some long-polling applications.