### PR TITLE
Fix Json pointer cast preventing use in CTFE.

### DIFF
--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -104,8 +104,11 @@ struct Json {
 		// memory leaks and, worse, std.algorithm.swap triggering an assertion
 		// because of internal pointers. This crude workaround seems to fix
 		// the issues.
-		void*[max((BigInt.sizeof+(void*).sizeof-1)/(void*).sizeof, 2)] m_data;
-		ref inout(T) getDataAs(T)() inout { static assert(T.sizeof <= m_data.sizeof); return *cast(inout(T)*)m_data.ptr; }
+		void[max((BigInt.sizeof+(void*).sizeof), 2)] m_data;
+		ref inout(T) getDataAs(T)() inout {
+			static assert(T.sizeof <= m_data.sizeof);
+			return (cast(inout(T)[1])m_data[0 .. T.sizeof])[0];
+		}
 
 		@property ref inout(BigInt) m_bigInt() inout { return getDataAs!BigInt(); }
 		@property ref inout(long) m_int() inout { return getDataAs!long(); }

--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -104,7 +104,11 @@ struct Json {
 		// memory leaks and, worse, std.algorithm.swap triggering an assertion
 		// because of internal pointers. This crude workaround seems to fix
 		// the issues.
-		void[max((BigInt.sizeof+(void*).sizeof), 2)] m_data;
+		enum m_size = max((BigInt.sizeof+(void*).sizeof), 2);
+		// NOTE : DMD 2.067.1 doesn't seem to init void[] correctly on its own.
+		// Explicity initializing it works around this issue.
+		void[m_size] m_data = (void[m_size]).init;
+
 		ref inout(T) getDataAs(T)() inout {
 			static assert(T.sizeof <= m_data.sizeof);
 			return (cast(inout(T)[1])m_data[0 .. T.sizeof])[0];

--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -1048,11 +1048,10 @@ struct Json {
 
 	private void initBigInt()
 	{
-		// BigInt is a struct, and it have a special BigInt.init value,  differs the null.
-		// m_data has no special initializer and when we tries to first access to BigInt
+		// BigInt is a struct, and it has a special BigInt.init value, which differs from null.
+		// m_data has no special initializer and when it tries to first access to BigInt
 		// via m_bigInt(), we should explicitly initialize m_data with BigInt.init
-		BigInt init_;
-		(cast(ubyte*)m_data.ptr)[0 .. BigInt.sizeof] = (cast(ubyte*)&init_)[0 .. BigInt.sizeof];
+		(cast(BigInt[1])m_data[0 .. BigInt.sizeof])[0] = BigInt.init;
 	}
 
 	private void runDestructors()


### PR DESCRIPTION
Json type used a pointer cast for conversions, which is illegal in CTFE.

Minimal case for reproduction:
```d
struct Charge
{
    Json json = Json.emptyObject; // CTFE error.
}
```

Previously caused this error,
```
..\..\dub\packages\vibe-d-0.7.29-beta.1\source\vibe\data\json.d(108,104): Error: reinterpreting cast from inout(void*)* to inout(Json[string])* is not supported in CTFE
..\..\dub\packages\vibe-d-0.7.29-beta.1\source\vibe\data\json.d(115,87):        called from here: this.getDataAs()
..\..\dub\packages\vibe-d-0.7.29-beta.1\source\vibe\data\json.d(189,56):        called from here: this.m_object()
..\..\dub\packages\vibe-d-0.7.29-beta.1\source\vibe\data\json.d(153,51):        called from here: Json(null, cast(Type)0).this(cast(Json[string])null)
source\test\charge.d(16,22):        called from here: emptyObject()
dmd failed with exit code 1.
```