### PR TITLE
Correct the client Websocket handshake

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -956,7 +956,8 @@ final class HTTPClientResponse : HTTPResponse {
 		enforce(statusCode == HTTPStatus.switchingProtocols, "Server did not send a 101 - Switching Protocols response");
 		string *resNewProto = "Upgrade" in headers;
 		enforce(resNewProto, "Server did not send an Upgrade header");
-		enforce(!new_protocol.length || *resNewProto == new_protocol, "Expected Upgrade: " ~ new_protocol ~", received Upgrade: " ~ *resNewProto);
+		enforce(!new_protocol.length || !icmp(*resNewProto, new_protocol),
+			"Expected Upgrade: " ~ new_protocol ~", received Upgrade: " ~ *resNewProto);
 		auto stream = new ConnectionProxyStream(m_client.m_stream, m_client.m_conn);
 		m_client.m_responding = false;
 		m_client = null;


### PR DESCRIPTION
The RFC specify in section 4.1 (Opening Handshake, Client Requirements) that:
"The value of this header field MUST be a nonce consisting of a randomly
selected 16-byte value that has been base64-encoded"

However `randomUUID.toString` would return a 36 chars string.
As a result, the base64 encoding was 48 chars long instead of 24.