### PR TITLE
Don't force immutability for string algorithms

### DIFF
--- a/source/vibe/textfilter/urlencode.d
+++ b/source/vibe/textfilter/urlencode.d
@@ -16,10 +16,12 @@ import std.exception;
 import std.format;
 
 
-/** Returns the URL encoded version of a given string.
-*/
-string urlEncode(string str, string allowed_chars = null)
-@safe {
+/**
+ * Returns:
+ *   the URL encoded version of a given string, in a newly-allocated string.
+ */
+T[] urlEncode(T)(T[] str, const(char)[] allowed_chars = null) if (is(T[] : const(char)[]))
+{
 	foreach (char c; str) {
 		switch(c) {
 			case '-':
@@ -31,7 +33,7 @@ string urlEncode(string str, string allowed_chars = null)
 			case '~':
 				break;
 			default:
-				auto dst = appender!string();
+				auto dst = appender!(T[]);
 				dst.reserve(str.length);
 				filterURLEncode(dst, str, allowed_chars);
 				return dst.data;
@@ -40,12 +42,12 @@ string urlEncode(string str, string allowed_chars = null)
 	return str;
 }
 
-unittest {
+@safe unittest {
 	string s = "hello-world";
 	assert(s.urlEncode().ptr == s.ptr);
 }
 
-private bool isCorrectHexNum(string str)
+private auto isCorrectHexNum(const(char)[] str)
 @safe {
 	foreach (char c; str) {
 		switch(c) {
@@ -62,7 +64,7 @@ private bool isCorrectHexNum(string str)
 
 /** Checks whether a given string has valid URL encoding.
 */
-bool isURLEncoded(string str, string reserved_chars = null)
+bool isURLEncoded(const(char)[] str, const(char)[] reserved_chars = null)
 @safe {
 	for (size_t i = 0; i < str.length; i++) {
 		switch(str[i]) {
@@ -90,7 +92,7 @@ bool isURLEncoded(string str, string reserved_chars = null)
 	return true;
 }
 
-unittest {
+@safe unittest {
 	assert(isURLEncoded("hello-world"));
 	assert(isURLEncoded("he%2F%af"));
 	assert(!isURLEncoded("hello world", " "));
@@ -100,10 +102,10 @@ unittest {
 
 /** Returns the decoded version of a given URL encoded string.
 */
-string urlDecode(string str)
-@safe {
+T[] urlDecode(T)(T[] str) if (is(T[] : const(char)[]))
+{
 	if (!str.anyOf("%")) return str;
-	auto dst = appender!string();
+	auto dst = appender!(T[]);
 	dst.reserve(str.length);
 	filterURLDecode(dst, str);
 	return dst.data;
@@ -117,9 +119,9 @@ string urlDecode(string str)
 	Note that newlines should always be represented as \r\n sequences
 	according to the HTTP standard.
 */
-string formEncode(string str, string allowed_chars = null)
-@safe {
-	auto dst = appender!string();
+T[] formEncode(T)(T[] str, const(char)[] allowed_chars = null) if (is(T[] : const(char)[]))
+{
+	auto dst = appender!(T[]);
 	dst.reserve(str.length);
 	filterURLEncode(dst, str, allowed_chars, true);
 	return dst.data;
@@ -130,8 +132,8 @@ string formEncode(string str, string allowed_chars = null)
 	Form encoding is the same as normal URL encoding, except that
 	spaces are replaced by plus characters.
 */
-string formDecode(string str)
-@safe {
+T[] formDecode(T)(T[] str) if (is(T[] : const(char)[]))
+{
 	if (!str.anyOf("%+")) return str;
 	auto dst = appender!string();
 	dst.reserve(str.length);
@@ -141,7 +143,9 @@ string formDecode(string str)
 
 /** Writes the URL encoded version of the given string to an output range.
 */
-void filterURLEncode(R)(ref R dst, string str, string allowed_chars = null, bool form_encoding = false)
+void filterURLEncode(R)(ref R dst, const(char)[] str,
+                        const(char)[] allowed_chars = null,
+                        bool form_encoding = false)
 {
 	while( str.length > 0 ) {
 		switch(str[0]) {
@@ -168,7 +172,7 @@ void filterURLEncode(R)(ref R dst, string str, string allowed_chars = null, bool
 
 /** Writes the decoded version of the given URL encoded string to an output range.
 */
-void filterURLDecode(R)(ref R dst, string str, bool form_encoding = false)
+void filterURLDecode(R)(ref R dst, const(char)[] str, bool form_encoding = false)
 {
 	while( str.length > 0 ) {
 		switch(str[0]) {

--- a/source/vibe/utils/string.d
+++ b/source/vibe/utils/string.d
@@ -49,7 +49,7 @@ string sanitizeUTF8(in ubyte[] str)
 	Strips the byte order mark of an UTF8 encoded string.
 	This is useful when the string is coming from a file.
 */
-string stripUTF8Bom(string str)
+inout(char)[] stripUTF8Bom(inout(char)[] str)
 @safe pure nothrow {
 	if (str.length >= 3 && str[0 .. 3] == [0xEF, 0xBB, 0xBF])
 		return str[3 ..$];
@@ -60,7 +60,7 @@ string stripUTF8Bom(string str)
 /**
 	Checks if all characters in 'str' are contained in 'chars'.
 */
-bool allOf(string str, string chars)
+bool allOf(const(char)[] str, const(char)[] chars)
 @safe pure {
 	foreach (dchar ch; str)
 		if (!chars.canFind(ch))
@@ -98,7 +98,7 @@ ptrdiff_t indexOfCT(Char)(in Char[] s, in Char[] needle)
 /**
 	Checks if any character in 'str' is contained in 'chars'.
 */
-bool anyOf(string str, string chars)
+bool anyOf(const(char)[] str, const(char)[] chars)
 @safe pure {
 	foreach (ch; str)
 		if (chars.canFind(ch))
@@ -108,7 +108,7 @@ bool anyOf(string str, string chars)
 
 
 /// ASCII whitespace trimming (space and tab)
-string stripLeftA(string s)
+inout(char)[] stripLeftA(inout(char)[] s)
 @safe pure nothrow {
 	while (s.length > 0 && (s[0] == ' ' || s[0] == '\t'))
 		s = s[1 .. $];
@@ -116,7 +116,7 @@ string stripLeftA(string s)
 }
 
 /// ASCII whitespace trimming (space and tab)
-string stripRightA(string s)
+inout(char)[] stripRightA(inout(char)[] s)
 @safe pure nothrow {
 	while (s.length > 0 && (s[$-1] == ' ' || s[$-1] == '\t'))
 		s = s[0 .. $-1];
@@ -124,13 +124,13 @@ string stripRightA(string s)
 }
 
 /// ASCII whitespace trimming (space and tab)
-string stripA(string s)
+inout(char)[] stripA(inout(char)[] s)
 @safe pure nothrow {
 	return stripLeftA(stripRightA(s));
 }
 
 /// Finds the first occurence of any of the characters in `chars`
-sizediff_t indexOfAny(string str, string chars)
+sizediff_t indexOfAny(const(char)[] str, const(char)[] chars)
 @safe pure {
 	foreach (i, char ch; str)
 		if (chars.canFind(ch))
@@ -149,7 +149,7 @@ alias countUntilAny = indexOfAny;
 		The index of the closing bracket or -1 for unbalanced strings
 		and strings that don't start with a bracket.
 */
-sizediff_t matchBracket(string str, bool nested = true)
+sizediff_t matchBracket(const(char)[] str, bool nested = true)
 @safe pure nothrow {
 	if (str.length < 2) return -1;
 
@@ -194,7 +194,7 @@ string formatAlloc(ARGS...)(Allocator alloc, string fmt, ARGS args)
 }
 
 /// Special version of icmp() with optimization for ASCII characters
-int icmp2(string a, string b)
+int icmp2(const(char)[] a, const(char)[] b)
 @safe pure {
 	size_t i = 0, j = 0;
 


### PR DESCRIPTION
When taking a string argument for validation, 'const(char)[]' should be used instead of 'string'.
That's because the former only promise the caller it won't modify the reference,
while the later ask for the strong promise (from the caller) that this argument shall never be modified.

In addition, some of those algorithm will either return a portion of the input string or a newly
allocated one.  This may result in a lot of otherwise avoidable allocations.  The runtime decision also
makes it impossible to use in `@nogc` code.
Ultimately, this code could be modified to take a buffer as parameter.
For the time being those functions were turned into templates.

Note: This is a rather shallow pass.