### PR TITLE
Added VibeDataNoOpDispatch version 

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -669,17 +669,22 @@ struct Bson {
 		return 0;
 	}
 
-	/** Deprecated, please use `opIndex` instead.
+	// If VibeDataNoOpDispatch is declared, don't include the depracted functions. This allows UFCS to be used on a Bson object
+	version (VibeDataNoOpDispatch) {
+	}
+	else {
+		/** Deprecated, please use `opIndex` instead.
 
-		Allows to access existing fields of a JSON object using dot syntax.
+			Allows to access existing fields of a JSON object using dot syntax.
 
-		Returns a null value for non-existent fields.
-	*/
-	deprecated("Use opIndex instead.")
-	@property inout(Bson) opDispatch(string prop)() inout { return opIndex(prop); }
-	/// ditto
-	deprecated("Use opIndexAssign instead.")
-	@property void opDispatch(string prop, T)(T val) { opIndexAssign(val, prop); }
+			Returns a null value for non-existent fields.
+		*/
+		deprecated("Use opIndex instead.")
+		@property inout(Bson) opDispatch(string prop)() inout { return opIndex(prop); }
+		/// ditto
+		deprecated("Use opIndexAssign instead.")
+		@property void opDispatch(string prop, T)(T val) { opIndexAssign(val, prop); }
+	}
 
 	///
 	bool opEquals(ref const Bson other) const {

--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -864,15 +864,20 @@ struct Json {
 		m_array ~= element;
 	}
 
-	/** Deprecated, please use `opIndex` instead.
+	// If VibeDataNoOpDispatch is declared, don't include the depracted functions. This allows UFCS to be used on a Json object
+	version (VibeDataNoOpDispatch) {
+	}
+	else {
+		/** Deprecated, please use `opIndex` instead.
 
-		Allows to access existing fields of a JSON object using dot syntax.
-	*/
-	deprecated("Use opIndex instead")
-	@property const(Json) opDispatch(string prop)() const { return opIndex(prop); }
-	/// ditto
-	deprecated("Use opIndex instead")
-	@property ref Json opDispatch(string prop)() { return opIndex(prop); }
+			Allows to access existing fields of a JSON object using dot syntax.
+		*/
+		deprecated("Use opIndex instead")
+		@property const(Json) opDispatch(string prop)() const { return opIndex(prop); }
+		/// ditto
+		deprecated("Use opIndex instead")
+		@property ref Json opDispatch(string prop)() { return opIndex(prop); }
+	}
 
 	/**
 		Compares two JSON values for equality.

--- a/source/vibe/db/mongo/collection.d
+++ b/source/vibe/db/mongo/collection.d
@@ -466,7 +466,7 @@ struct MongoCollection {
 		cmd.dropIndexes = m_name;
 		cmd.index = name;
 		auto reply = database.runCommand(cmd);
-		enforce(reply.ok.get!double == 1, "dropIndex command failed.");
+		enforce(reply["ok"].get!double == 1, "dropIndex command failed.");
 	}
 
 	void drop() {
@@ -477,7 +477,7 @@ struct MongoCollection {
 		CMD cmd;
 		cmd.drop = m_name;
 		auto reply = database.runCommand(cmd);
-		enforce(reply.ok.get!double == 1, "drop command failed.");
+		enforce(reply["ok"].get!double == 1, "drop command failed.");
 	}
 }
 

--- a/source/vibe/db/mongo/collection.d
+++ b/source/vibe/db/mongo/collection.d
@@ -276,12 +276,12 @@ struct MongoCollection {
 		cmd.count = m_name;
 		cmd.query = query;
 		auto reply = database.runCommand(cmd);
-		enforce(reply.ok.opt!double == 1 || reply.ok.opt!int == 1, "Count command failed.");
-		switch (reply.n.type) with (Bson.Type) {
+		enforce(reply["ok"].opt!double == 1 || reply["ok"].opt!int == 1, "Count command failed.");
+		switch (reply["n"].type) with (Bson.Type) {
 			default: assert(false, "Unsupported data type in BSON reply for COUNT");
-			case double_: return cast(ulong)reply.n.get!double; // v2.x
-			case int_: return reply.n.get!int; // v3.x
-			case long_: return reply.n.get!long; // just in case
+			case double_: return cast(ulong)reply["n"].get!double; // v2.x
+			case int_: return reply["n"].get!int; // v3.x
+			case long_: return reply["n"].get!long; // just in case
 		}
 	}
 

--- a/source/vibe/db/mongo/connection.d
+++ b/source/vibe/db/mongo/connection.d
@@ -278,11 +278,11 @@ final class MongoConnection {
 			(idx, ref error) {
 				try {
 					ret = MongoErrorDescription(
-						error.err.opt!string(""),
-						error.code.opt!int(-1),
-						error.connectionId.opt!int(-1),
-						error.n.get!int(),
-						error.ok.get!double()
+						error["err"].opt!string(""),
+						error["code"].opt!int(-1),
+						error["connectionId"].opt!int(-1),
+						error["n"].get!int(),
+						error["ok"].get!double()
 					);
 				} catch (Exception e) {
 					throw new MongoDriverException(e.msg);

--- a/source/vibe/http/dist.d
+++ b/source/vibe/http/dist.d
@@ -26,10 +26,10 @@ import std.process;
 void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handler, string balancer_address, ushort balancer_port = 11000)
 {
 	Json regmsg = Json.emptyObject;
-	regmsg.host_name = settings.hostName;
-	regmsg.port = settings.port;
-	regmsg.ssl_settings = "";
-	regmsg.pid = thisProcessID;
+	regmsg["host_name"] = settings.hostName;
+	regmsg["port"] = settings.port;
+	regmsg["ssl_settings"] = "";
+	regmsg["pid"] = thisProcessID;
 	//regmsg.sslContext = settings.sslContext; // TODO: send key/cert contents
 
 	HTTPServerSettings local_settings = settings.dup;
@@ -40,8 +40,8 @@ void listenHTTPDist(HTTPServerSettings settings, HTTPServerRequestDelegate handl
 
 	requestHTTP(URL("http://"~balancer_address~":"~to!string(balancer_port)~"/register"), (scope req){
 			logInfo("Listening for VibeDist connections on port %d", req.localAddress.port);
-			regmsg.local_address = "127.0.0.1";
-			regmsg.local_port = req.localAddress.port;
+			regmsg["local_address"] = "127.0.0.1";
+			regmsg["local_port"] = req.localAddress.port;
 			req.method = HTTPMethod.POST;
 			req.writeJsonBody(regmsg);
 		}, (scope res){

--- a/source/vibe/web/common.d
+++ b/source/vibe/web/common.d
@@ -415,8 +415,8 @@ class RestException : HTTPStatusException {
 	///
 	this(int status, Json jsonResult, string file = __FILE__, int line = __LINE__, Throwable next = null)
 	{
-		if (jsonResult.type == Json.Type.Object && jsonResult.statusMessage.type == Json.Type.String) {
-			super(status, jsonResult.statusMessage.get!string, file, line, next);
+		if (jsonResult.type == Json.Type.Object && jsonResult["statusMessage"].type == Json.Type.String) {
+			super(status, jsonResult["statusMessage"].get!string, file, line, next);
 		}
 		else {
 			super(status, httpStatusText(status) ~ " (" ~ jsonResult.toString() ~ ")", file, line, next);


### PR DESCRIPTION
This should not break existing code but allows us to define a version VibeDataNoOpDispatch. This prevents the compilation of the opDispatch functions in both Bson and Json.

We are semi-regularly running into issues with people using UFCS on a Json object. Instead of calling the function, it uses opDispatch and more often than not returns Json.undefined. This compiles without a problem and sometimes drives you mad when tests fail and you can't see the (not so) obvious issue.

Considering they are deprecated anyway, this allows a nice way for people to throw away this functionality immediately and make better use of things like UFCS.