### PR TITLE
Websockets: Add a client test again the autobahn testsuite + improvements

### DIFF
--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -409,7 +409,7 @@ final class WebSocket {
 		On the JavaScript side, the text will be available as message.data (type Blob).
 		Throws: WebSocketException if the connection is closed.
 	*/
-	void send(ubyte[] data)
+	void send(in ubyte[] data)
 	{
 		send((scope message){ message.write(data); }, FrameOpcode.binary);
 	}

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -405,7 +405,9 @@ final class WebSocket {
 	*/
 	void send(scope const(char)[] data)
 	{
-		send((scope message){ message.write(cast(const ubyte[])data); });
+		send(
+			(scope message) { message.write(cast(const ubyte[])data); },
+			FrameOpcode.text);
 	}
 
 	/**
@@ -423,7 +425,8 @@ final class WebSocket {
 		Sends a message using an output stream.
 		Throws: WebSocketException if the connection is closed.
 	*/
-	void send(scope void delegate(scope OutgoingWebSocketMessage) sender, FrameOpcode frameOpcode = FrameOpcode.text)
+	void send(scope void delegate(scope OutgoingWebSocketMessage) sender,
+			  FrameOpcode frameOpcode)
 	{
 		m_writeMutex.performLocked!({
 			enforceEx!WebSocketException(!m_sentCloseFrame, "WebSocket connection already actively closed.");
@@ -431,6 +434,13 @@ final class WebSocket {
 			scope(exit) message.finalize();
 			sender(message);
 		});
+	}
+
+	/// Compatibility overload - will be removed soon.
+	deprecated("Call the overload which requires an explicit FrameOpcode.")
+	void send(scope void delegate(scope OutgoingWebSocketMessage) sender)
+	{
+		send(sender, FrameOpcode.text);
 	}
 
 	/**

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -57,6 +57,9 @@ import vibe.crypto.cryptorand;
 /// Exception thrown by $(D vibe.http.websockets).
 class WebSocketException: Exception
 {
+	// @nogc cannot be applied to 2.067 because Exception.ctor is not @nogc
+	@safe pure nothrow:
+
 	///
 	this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
 	{

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -778,7 +778,6 @@ struct Frame {
 		bool masked = (data2[1] & 0x80) == 0x80;
 		frame.opcode = cast(FrameOpcode)(data2[0] & 0xf);
 
-		logDebug("Read frame: %s %s", frame.opcode, frame.fin);
 		//parsing length
 		ulong length = data2[1] & 0x7f;
 		if( length == 126 ) {
@@ -788,6 +787,11 @@ struct Frame {
 			stream.read(data8);
 			length = bigEndianToNative!ulong(data8);
 		}
+		logDebug("Read frame: %s %s %s length=%d",
+				 frame.opcode,
+				 frame.fin ? "final frame" : "continuation",
+				 masked ? "masked" : "not masked",
+				 length);
 
 		//masking key
 		ubyte[4] maskingKey;

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -739,13 +739,13 @@ private static immutable s_webSocketGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11
 
 
 /**
- * The Opcode is 4 bytes, as defined in Section 5.2
+ * The Opcode is 4 bits, as defined in Section 5.2
  *
  * Values are defined in section 11.8
  * Currently only 6 values are defined, however the opcode is defined as
- * taking 4 bytes.
+ * taking 4 bits.
  */
-enum FrameOpcode : uint {
+enum FrameOpcode : ubyte {
 	continuation = 0x0,
 	text = 0x1,
 	binary = 0x2,
@@ -753,51 +753,164 @@ enum FrameOpcode : uint {
 	ping = 0x9,
 	pong = 0xA
 }
+static assert(FrameOpcode.max < 0b1111, "FrameOpcode is only 4 bits");
 
 
 struct Frame {
-	bool fin;
-	FrameOpcode opcode;
+	/**
+	   Contains the first byte of the frame:
+	   - The FIN bit
+	   - The 3 reserved bits RSV1, RSV2, RSV3
+	   - The 4-bits opcode
+	*/
+	ubyte fin_rsv_opcode;
 	ubyte[] payload;
 
-	void writeFrame(OutputStream stream, SystemRNG sys_rng)
+    /**
+     * Get or set the 'final' bit of this frame,
+     * which is the first bit of the frame
+     */
+    @property bool fin (bool n) pure nothrow @safe @nogc
+    {
+        if (n)
+            this.fin_rsv_opcode |= 0b1000_0000;
+        else
+            this.fin_rsv_opcode &= 0b0111_1111;
+        return n;
+    }
+
+    /// Ditto
+    @property bool fin () const pure nothrow @safe @nogc
+    {
+        return !!(this.fin_rsv_opcode & 0b1000_0000);
+    }
+
+
+    /**
+     * Get or set the opcode of this frame,
+     * which is the lower 4 bits of the first byte
+     */
+    @property FrameOpcode opcode (FrameOpcode n) pure nothrow @safe @nogc
+    {
+        this.fin_rsv_opcode = (this.fin_rsv_opcode & 0b1111_0000) | n;
+        return n;
+    }
+
+    /// Ditto
+    @property FrameOpcode opcode () const pure nothrow @safe @nogc
+    {
+        return cast(FrameOpcode)(this.fin_rsv_opcode & 0b0000_1111);
+    }
+
+    /**
+     * Return the payload length encoded with the expected amount of bits
+     *
+     * The WebSocket RFC define a variable-length payload length.
+     * In short, it means that:
+     * - If the length is <= 125, it is stored as the 7 least significant
+     *   bits of the second header byte.  The first bit is reserved for MASK.
+     * - If the length is <= 65_536 (so it fits in 2 bytes), a magic value of
+     *   126 is stored in the aforementioned 7 bits, and the actual length
+     *   is stored in the next two bytes, resulting in a 4 bytes header
+     *   ( + masking key, if any).
+     * - If the length is > 65_536, a magic value of 127 will be used for
+     *   the 7-bit field, and the next 8 bytes are expected to be the length,
+     *   resulting in a 10 bytes header ( + masking key, if any).
+     *
+     * Those functions encapsulate all this logic and allow to just get the
+     * length with the desired size.
+     *
+     * Return:
+     * - For `ubyte`, the value to store in the 7 bits field, either the
+     *   length or a magic value (126 or 127).
+     * - For `ushort`, a value in the range [126; 65_536].
+     *   If payload.length is not in this bound, an assertion will be triggered.
+     * - For `ulong`, a value in the range [65_537; size_t.max].
+     *   If payload.length is not in this bound, an assertion will be triggered.
+     */
+    private ubyte smallPayloadLength(bool masked) const pure nothrow @safe @nogc
+    {
+		// Note: If length == 126, we need to use the 2 bytes anyway
+		const ubyte m = masked ? 0b1000_0000 : 0;
+		if (this.payload.length > ushort.max)
+			return 127 | m;
+		else if (this.payload.length > 125)
+			return 126 | m;
+		else
+			return cast(ubyte)this.payload.length | m;
+	}
+
+	/// Ditto
+	private ushort shortPayloadLength() const pure nothrow @safe @nogc
 	{
+		assert(this.payload.length >= 126,
+			   "ushort version shouldn't be called when payload < 126");
+		assert(this.payload.length <= ushort.max,
+			   "ushort version shouldn't be called when payload > ushort.max");
+		return cast(ushort)this.payload.length;
+	}
+
+	/// Ditto
+	private ulong longPayloadLength() const pure nothrow @safe @nogc
+	{
+		assert(this.payload.length > ushort.max,
+			   "ulong version shouldn't be called when payload <= ushort.max");
+		return this.payload.length;
+	}
+
+
+    /**
+     * Write a single Websocket frame to the output stream
+     *
+     * Params:
+     * stream = The connection to write to. Required parameter.
+     * sys_rng = The source of entropy to use.
+     *           If this parameter is provided, it is assumed
+     *           that this frame should be masked (mandatory for
+     *           client frame), in which case the payload will
+     *           be XOR-ed using a 32 bits value.
+     *           Default to null (client frame).
+     *
+     * See_Also:
+     * https://tools.ietf.org/html/rfc6455#section-5.2
+     * for a broad overview.
+     */
+	void writeFrame(OutputStream stream, SystemRNG sys_rng = null)
+	{
+
+		import std.bitmanip : nativeToBigEndian;
 		import vibe.stream.wrapper;
 
 		auto rng = StreamOutputRange(stream);
-
 		ubyte[4] buff;
-		ubyte firstByte = cast(ubyte)opcode;
-		if (fin) firstByte |= 0x80;
-		rng.put(firstByte);
+
+		// The first byte of the header
+		rng.put(this.fin_rsv_opcode);
 
 		auto b1 = 0;
 		if (sys_rng) {
 			b1 = 0x80;
 		}
 
-		if( payload.length < 126 ) {
-			rng.put(std.bitmanip.nativeToBigEndian(cast(ubyte)(b1 | payload.length)));
-		} else if( payload.length <= 65536 ) {
-			buff[0] = cast(ubyte) (b1 | 126);
-			rng.put(buff[0 .. 1]);
-			rng.put(std.bitmanip.nativeToBigEndian(cast(ushort)payload.length));
-		} else {
-			buff[0] = cast(ubyte) (b1 | 127);
-			rng.put(buff[0 .. 1]);
-			rng.put(std.bitmanip.nativeToBigEndian(payload.length));
-		}
+		// Writing the basic payload length
+		rng.put(nativeToBigEndian(this.smallPayloadLength(!!sys_rng)));
+		if (payload.length < 126) {}
+		else if (payload.length <= ushort.max)
+			rng.put(nativeToBigEndian(this.shortPayloadLength));
+		else
+			rng.put(nativeToBigEndian(this.longPayloadLength));
 
-		if (sys_rng) {
+		if (sys_rng) { // Client Frame
 			sys_rng.read(buff);
 			rng.put(buff);
 			for (size_t i = 0; i < payload.length; i++) {
 				payload[i] ^= buff[i % 4];
 			}
 			rng.put(payload);
-		}else {
+		} else { // Server frame
 			rng.put(payload);
 		}
+
 		rng.flush();
 		stream.flush();
 	}

--- a/tests/not-runnable/vibe.http.websocket-autobahn-client/.gitignore
+++ b/tests/not-runnable/vibe.http.websocket-autobahn-client/.gitignore
@@ -1,0 +1,6 @@
+websockets-autobahn-client
+.dub
+docs.json
+__dummy.html
+*.o
+*.obj

--- a/tests/not-runnable/vibe.http.websocket-autobahn-client/dub.json
+++ b/tests/not-runnable/vibe.http.websocket-autobahn-client/dub.json
@@ -1,0 +1,9 @@
+{
+	"name": "websockets-autobahn-client",
+	"dependencies": {
+		"vibe-d": { "path": "../../" }
+	},
+	"versions": [
+		"VibeDefaultMain"
+	]
+}

--- a/tests/not-runnable/vibe.http.websocket-autobahn-client/source/app.d
+++ b/tests/not-runnable/vibe.http.websocket-autobahn-client/source/app.d
@@ -1,0 +1,41 @@
+import vibe.d;
+
+shared static this ()
+{
+    runTask(() => runTestSuite());
+}
+
+void runTestSuite ()
+{
+    auto count = getCaseCount();
+    logInfo("We're going to run %d test cases...", count);
+
+    foreach (currCase; 1 .. count)
+    {
+        auto url = URL("ws://127.0.0.1:9001/runCase?agent=vibe.d&case="
+                       ~ to!string(currCase));
+        logInfo("Running test case %d/%d", currCase, count);
+        connectWebSocket(
+            url, (scope ws) {
+                while (ws.waitForData) {
+                    ws.receive((scope message) {
+                        ws.send(message.readAll);
+                    });
+                }
+            });
+    }
+}
+
+
+size_t getCaseCount (string base_addr = "ws://127.0.0.1:9001")
+{
+    size_t ret;
+    auto url = URL(base_addr ~ "/getCaseCount");
+    connectWebSocket(
+        url, (scope ws) {
+            while (ws.waitForData) {
+                ret = ws.receiveText.to!size_t;
+            }
+        });
+    return ret;
+}

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -20,7 +20,9 @@ if [ ${BUILD_EXAMPLE=1} -eq 1 ]; then
 fi
 if [ ${RUN_TEST=1} -eq 1 ]; then
     for ex in `\ls -1 tests/`; do
-        echo "[INFO] Running test $ex"
-        (cd tests/$ex && dub --compiler=$DC && dub clean)
+        if [ -r test/$ex/dub.json ] || [ -r test/$ex/dub.sdl ]; then
+            echo "[INFO] Running test $ex"
+            (cd tests/$ex && dub --compiler=$DC && dub clean)
+        fi
     done
 fi


### PR DESCRIPTION
Here's a couple of improvements to the Websockets implementation.

First, a new 'test', which is not run by default, against the autobahn testsuite (see https://github.com/rejectedsoftware/vibe.d/issues/1505 ).
Currently, it passes 517 out of 519 test cases (it blocks on the 518th, haven't investigated yet).

The other improvements are mostly cosmetic / performance: reduce the size of the `Frame`, document everything, provide a better encapsulation...

There's a change to the API, where 'send' with a message doesn't assume the data to be text anymore, and `send` didn't accept `const(ubyte)[]` - even though it was just forwarding to a const-accepting method.
