### PR TITLE
Let serializers get a type traits struct instead of the raw type.

### DIFF
--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -1347,34 +1347,34 @@ struct BsonSerializer {
 		return ret;
 	}
 
-	void beginWriteDictionary(T)()
+	void beginWriteDictionary(Traits)()
 	{
 		writeCompositeEntryHeader(Bson.Type.object);
 		m_compositeStack ~= m_dst.data.length;
 		m_dst.put(toBsonData(cast(int)0));
 	}
-	void endWriteDictionary(T)()
+	void endWriteDictionary(Traits)()
 	{
 		m_dst.put(Bson.Type.end);
 		auto sh = m_compositeStack[$-1];
 		m_compositeStack.length--;
 		m_dst.data[sh .. sh + 4] = toBsonData(cast(uint)(m_dst.data.length - sh))[];
 	}
-	void beginWriteDictionaryEntry(T)(string name) { m_entryName = name; }
-	void endWriteDictionaryEntry(T)(string name) {}
+	void beginWriteDictionaryEntry(Traits)(string name) { m_entryName = name; }
+	void endWriteDictionaryEntry(Traits)(string name) {}
 
-	void beginWriteArray(T)(size_t)
+	void beginWriteArray(Traits)(size_t)
 	{
 		writeCompositeEntryHeader(Bson.Type.array);
 		m_compositeStack ~= m_dst.data.length;
 		m_dst.put(toBsonData(cast(int)0));
 	}
-	void endWriteArray(T)() { endWriteDictionary!T(); }
-	void beginWriteArrayEntry(T)(size_t idx) { m_entryIndex = idx; }
-	void endWriteArrayEntry(T)(size_t idx) {}
+	void endWriteArray(Traits)() { endWriteDictionary!Traits(); }
+	void beginWriteArrayEntry(Traits)(size_t idx) { m_entryIndex = idx; }
+	void endWriteArrayEntry(Traits)(size_t idx) {}
 
 	// auto ref does't work for DMD 2.064
-	void writeValue(T)(/*auto ref const*/ in T value) { writeValueH!(T, true)(value); }
+	void writeValue(Traits, T)(/*auto ref const*/ in T value) { writeValueH!(T, true)(value); }
 
 	private void writeValueH(T, bool write_header)(/*auto ref const*/ in T value)
 	{
@@ -1428,7 +1428,7 @@ struct BsonSerializer {
 	//
 	// deserialization
 	//
-	void readDictionary(T)(scope void delegate(string) entry_callback)
+	void readDictionary(Traits)(scope void delegate(string) entry_callback)
 	{
 		enforce(m_inputData.type == Bson.Type.object, "Expected object instead of "~m_inputData.type.to!string());
 		auto old = m_inputData;
@@ -1439,7 +1439,7 @@ struct BsonSerializer {
 		m_inputData = old;
 	}
 
-	void readArray(T)(scope void delegate(size_t) size_callback, scope void delegate() entry_callback)
+	void readArray(Traits)(scope void delegate(size_t) size_callback, scope void delegate() entry_callback)
 	{
 		enforce(m_inputData.type == Bson.Type.array, "Expected array instead of "~m_inputData.type.to!string());
 		auto old = m_inputData;
@@ -1450,7 +1450,7 @@ struct BsonSerializer {
 		m_inputData = old;
 	}
 
-	T readValue(T)()
+	T readValue(Traits, T)()
 	{
 		static if (is(T == Bson)) return m_inputData;
 		else static if (is(T == Json)) return m_inputData.toJson();
@@ -1473,8 +1473,8 @@ struct BsonSerializer {
 			if (m_inputData.type == Bson.Type.string) return SysTime.fromISOExtString(m_inputData.get!string);
 			else return m_inputData.get!BsonDate().toSysTime();
 		}
-		else static if (isBsonSerializable!T) return T.fromBson(readValue!Bson);
-		else static if (isJsonSerializable!T) return T.fromJson(readValue!Bson.toJson());
+		else static if (isBsonSerializable!T) return T.fromBson(readValue!(Traits, Bson));
+		else static if (isJsonSerializable!T) return T.fromJson(readValue!(Traits, Bson).toJson());
 		else static if (is(T : const(ubyte)[])) {
 			auto ret = m_inputData.get!BsonBinData.rawData;
 			static if (isStaticArray!T) return cast(T)ret[0 .. T.length];
@@ -1483,7 +1483,7 @@ struct BsonSerializer {
 		} else return m_inputData.get!T();
 	}
 
-	bool tryReadNull()
+	bool tryReadNull(Traits)()
 	{
 		if (m_inputData.type == Bson.Type.null_) return true;
 		return false;

--- a/source/vibe/data/bson.d
+++ b/source/vibe/data/bson.d
@@ -1439,6 +1439,9 @@ struct BsonSerializer {
 		m_inputData = old;
 	}
 
+	void beginReadDictionaryEntry(Traits)(string name) {}
+	void endReadDictionaryEntry(Traits)(string name) {}
+
 	void readArray(Traits)(scope void delegate(size_t) size_callback, scope void delegate() entry_callback)
 	{
 		enforce(m_inputData.type == Bson.Type.array, "Expected array instead of "~m_inputData.type.to!string());
@@ -1449,6 +1452,9 @@ struct BsonSerializer {
 		}
 		m_inputData = old;
 	}
+
+	void beginReadArrayEntry(Traits)(size_t index) {}
+	void endReadArrayEntry(Traits)(size_t index) {}
 
 	T readValue(Traits, T)()
 	{

--- a/source/vibe/data/json.d
+++ b/source/vibe/data/json.d
@@ -1609,6 +1609,9 @@ struct JsonSerializer {
 		m_current = old;
 	}
 
+	void beginReadDictionaryEntry(Traits)(string name) {}
+	void endReadDictionaryEntry(Traits)(string name) {}
+
 	void readArray(Traits)(scope void delegate(size_t) size_callback, scope void delegate() entry_callback)
 	{
 		enforceJson(m_current.type == Json.Type.array, "Expected JSON array, got "~m_current.type.to!string);
@@ -1620,6 +1623,9 @@ struct JsonSerializer {
 		}
 		m_current = old;
 	}
+
+	void beginReadArrayEntry(Traits)(size_t index) {}
+	void endReadArrayEntry(Traits)(size_t index) {}
 
 	T readValue(Traits, T)()
 	{
@@ -1778,6 +1784,9 @@ struct JsonStringSerializer(R, bool pretty = false)
 			}
 		}
 
+		void beginReadDictionaryEntry(Traits)(string name) {}
+		void endReadDictionaryEntry(Traits)(string name) {}
+
 		void readArray(Traits)(scope void delegate(size_t) size_callback, scope void delegate() entry_callback)
 		{
 			m_range.skipWhitespace(&m_line);
@@ -1798,6 +1807,9 @@ struct JsonStringSerializer(R, bool pretty = false)
 				entry_callback();
 			}
 		}
+
+		void beginReadArrayEntry(Traits)(size_t index) {}
+		void endReadArrayEntry(Traits)(size_t index) {}
 
 		T readValue(Traits, T)()
 		{

--- a/source/vibe/data/serialization.d
+++ b/source/vibe/data/serialization.d
@@ -204,7 +204,7 @@ unittest {
 	import vibe.data.json;
 
 	template SizePol(T)
-		if (__traits(allMembers, T) == AliasSeq!("x", "y"))
+		if (__traits(allMembers, T) == TypeTuple!("x", "y"))
 	{
 		import std.conv;
 		import std.array;
@@ -292,7 +292,7 @@ unittest {
 	import vibe.data.json;
 
 	template SizePol(T)
-		if (__traits(allMembers, T) == AliasSeq!("x", "y"))
+		if (__traits(allMembers, T) == TypeTuple!("x", "y"))
 	{
 		import std.conv;
 		import std.array;

--- a/source/vibe/data/serialization.d
+++ b/source/vibe/data/serialization.d
@@ -67,6 +67,8 @@
 
 			// serialization
 			auto getSerializedResult();
+			void beginWriteDocument(TypeTraits)();
+			void endWriteDocument(TypeTraits)();
 			void beginWriteDictionary(T)();
 			void endWriteDictionary(T)();
 			void beginWriteDictionaryEntry(T)(string name);
@@ -169,7 +171,11 @@ auto serializeWithPolicy(Serializer, alias Policy, T, ARGS...)(T value, ARGS arg
 /// ditto
 void serializeWithPolicy(Serializer, alias Policy, T)(ref Serializer serializer, T value)
 {
+	static if (is(typeof(serializer.beginWriteDocument!T())))
+		serializer.beginWriteDocument!T();
 	serializeValueImpl!(Serializer, Policy).serializeValue!T(serializer, value);
+	static if (is(typeof(serializer.endWriteDocument!T())))
+		serializer.endWriteDocument!T();
 }
 ///
 version (unittest)


### PR DESCRIPTION
This is a breaking change for any serializer implementations. The expectation though is that the only existing seriailzer implementations are currently the ones in vibe.d itself.

The traits struct in particular carries UDA information, which allows serializers to support serializer specific UDAs. The code has also been refactored a bit to reduce line length/visual noise.