### PR TITLE
set gzip output stream in HTTPClientRequest's bodyWriter()

### DIFF
--- a/source/vibe/http/client.d
+++ b/source/vibe/http/client.d
@@ -705,6 +705,8 @@ final class HTTPClientRequest : HTTPRequest {
 
 		writeHeader();
 		m_bodyWriter = m_conn;
+		if (headers.get("Content-Encoding", null) == "gzip")
+			m_bodyWriter = new GzipOutputStream(m_bodyWriter);
 
 		if (headers.get("Transfer-Encoding", null) == "chunked")
 			m_bodyWriter = new ChunkedOutputStream(m_bodyWriter);


### PR DESCRIPTION
when content-encoding is set to gzip
#1544 