### PR TITLE
disallow defining VibeCustomMain and VibeDefaultMain together

### DIFF
--- a/source/vibe/appmain.d
+++ b/source/vibe/appmain.d
@@ -20,6 +20,9 @@
 */
 module vibe.appmain;
 
+version (VibeCustomMain) version (VibeDefaultMain)
+	static assert(false, "versions VibeCustomMain and VibeDefaultMain cannot both be defined");
+
 version (VibeDefaultMain):
 
 /**


### PR DESCRIPTION
I don't know how, but I ended up with both of these defined and it caused a headache, perhaps this will help others see the problem quickly