### PR TITLE
Add build configuration for Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,421 @@
+project('Vibe.d', 'd')
+
+source_root = meson.source_root()
+build_root = meson.build_root()
+
+project_version      = '0.7.30'
+project_version_name = '0.7.30~beta.1'
+project_soversion    = '0'
+
+pkgc = import('pkgconfig')
+
+#
+# Sources
+#
+src_dir = include_directories('source/')
+
+vibe_main_src = [
+    'source/vibe/appmain.d',
+    'source/vibe/d.d',
+    'source/vibe/vibe.d'
+]
+install_headers(vibe_main_src, subdir: 'd/vibe')
+
+vibe_core_src = [
+    'source/vibe/core/task.d',
+    'source/vibe/core/sync.d',
+    'source/vibe/core/concurrency.d',
+    'source/vibe/core/file.d',
+    'source/vibe/core/log.d',
+    'source/vibe/core/connectionpool.d',
+    'source/vibe/core/args.d',
+    'source/vibe/core/stream.d',
+    'source/vibe/core/drivers/libasync.d',
+    'source/vibe/core/drivers/utils.d',
+    'source/vibe/core/drivers/native.d',
+    'source/vibe/core/drivers/threadedfile.d',
+    'source/vibe/core/drivers/libevent2.d',
+    'source/vibe/core/drivers/winrt.d',
+    'source/vibe/core/drivers/timerqueue.d',
+    'source/vibe/core/drivers/win32.d',
+    'source/vibe/core/drivers/libevent2_tcp.d',
+    'source/vibe/core/net.d',
+    'source/vibe/core/core.d',
+    'source/vibe/core/driver.d'
+]
+install_headers(vibe_core_src, subdir: 'd/vibe/core')
+
+vibe_crypto_src = [
+    'source/vibe/crypto/passwordhash.d',
+    'source/vibe/crypto/cryptorand.d'
+]
+install_headers(vibe_crypto_src, subdir: 'd/vibe/crypto')
+
+vibe_inet_src = [
+    'source/vibe/inet/path.d',
+    'source/vibe/inet/url.d',
+    'source/vibe/inet/mimetypes.d',
+    'source/vibe/inet/webform.d',
+    'source/vibe/inet/urltransfer.d',
+    'source/vibe/inet/message.d'
+]
+install_headers(vibe_inet_src, subdir: 'd/vibe/inet')
+
+vibe_stream_src = [
+    'source/vibe/stream/botan.d',
+    'source/vibe/stream/counting.d',
+    'source/vibe/stream/taskpipe.d',
+    'source/vibe/stream/base64.d',
+    'source/vibe/stream/zlib.d',
+    'source/vibe/stream/stdio.d',
+    'source/vibe/stream/multicast.d',
+    'source/vibe/stream/openssl.d',
+    'source/vibe/stream/tls.d',
+    'source/vibe/stream/operations.d',
+    'source/vibe/stream/memory.d',
+    'source/vibe/stream/wrapper.d'
+]
+install_headers(vibe_stream_src, subdir: 'd/vibe/stream')
+
+vibe_textfilter_src = [
+    'source/vibe/textfilter/markdown.d',
+    'source/vibe/textfilter/urlencode.d',
+    'source/vibe/textfilter/html.d'
+]
+install_headers(vibe_textfilter_src, subdir: 'd/vibe/textfilter')
+
+vibe_utils_src = [
+    'source/vibe/utils/validation.d',
+    'source/vibe/utils/hashmap.d',
+    'source/vibe/utils/array.d',
+    'source/vibe/utils/dictionarylist.d',
+    'source/vibe/utils/memory.d',
+    'source/vibe/utils/string.d'
+]
+install_headers(vibe_utils_src, subdir: 'd/vibe/utils')
+
+vibe_internal_src = [
+    'source/vibe/internal/win32.d',
+    'source/vibe/internal/meta/funcattr.d',
+    'source/vibe/internal/meta/traits.d',
+    'source/vibe/internal/meta/typetuple.d',
+    'source/vibe/internal/meta/codegen.d',
+    'source/vibe/internal/meta/all.d',
+    'source/vibe/internal/meta/uda.d',
+    'source/vibe/internal/rangeutil.d'
+]
+install_headers(vibe_internal_src, subdir: 'd/vibe/internal')
+
+vibe_data_src = [
+    'source/vibe/data/bson.d',
+    'source/vibe/data/serialization.d',
+    'source/vibe/data/json.d'
+]
+install_headers(vibe_data_src, subdir: 'd/vibe/data')
+
+vibe_http_src = [
+    'source/vibe/http/session.d',
+    'source/vibe/http/proxy.d',
+    'source/vibe/http/dist.d',
+    'source/vibe/http/router.d',
+    'source/vibe/http/common.d',
+    'source/vibe/http/server.d',
+    'source/vibe/http/log.d',
+    'source/vibe/http/auth/basic_auth.d',
+    'source/vibe/http/auth/digest_auth.d',
+    'source/vibe/http/websockets.d',
+    'source/vibe/http/client.d',
+    'source/vibe/http/form.d',
+    'source/vibe/http/fileserver.d',
+    'source/vibe/http/status.d'
+]
+install_headers(vibe_http_src, subdir: 'd/vibe/http')
+
+vibe_mail_src = [
+    'source/vibe/mail/smtp.d',
+]
+install_headers(vibe_mail_src, subdir: 'd/vibe/mail')
+
+vibe_diet_src = [
+    'source/vibe/templ/parsertools.d',
+    'source/vibe/templ/utils.d',
+    'source/vibe/templ/diet.d'
+]
+install_headers(vibe_diet_src, subdir: 'd/vibe/templ')
+
+vibe_db_mongo_src = [
+    'source/vibe/db/mongo/connection.d',
+    'source/vibe/db/mongo/database.d',
+    'source/vibe/db/mongo/cursor.d',
+    'source/vibe/db/mongo/collection.d',
+    'source/vibe/db/mongo/client.d',
+    'source/vibe/db/mongo/mongo.d',
+    'source/vibe/db/mongo/settings.d',
+    'source/vibe/db/mongo/flags.d'
+]
+install_headers(vibe_db_mongo_src, subdir: 'd/vibe/db/mongo')
+
+vibe_db_redis_src = [
+    'source/vibe/db/redis/idioms.d',
+    'source/vibe/db/redis/types.d',
+    'source/vibe/db/redis/sessionstore.d',
+    'source/vibe/db/redis/redis.d'
+]
+install_headers(vibe_db_redis_src, subdir: 'd/vibe/db/redis')
+
+vibe_web_src = [
+    'source/vibe/web/validation.d',
+    'source/vibe/web/common.d',
+    'source/vibe/web/web.d',
+    'source/vibe/web/internal/rest/common.d',
+    'source/vibe/web/internal/rest/jsclient.d',
+    'source/vibe/web/auth.d',
+    'source/vibe/web/rest.d',
+    'source/vibe/web/i18n.d'
+]
+install_headers(vibe_web_src, subdir: 'd/vibe/web')
+
+#
+# Dependencies
+#
+zlib_dep = dependency('zlib')
+crypto_dep = dependency('libcrypto')
+ssl_dep = dependency('libssl')
+libevent_dep = dependency('libevent')
+
+external_subprojects_dir = build_root + '/subprojects'
+
+# Try to find system OpenSSL bindings, if not found, download
+# a Git copy.
+openssl_src_dir = ''
+if run_command('[', '-d', '/usr/include/d/common/deimos/openssl/', ']').returncode() == 0
+    openssl_src_dir = '/usr/include/d/common'
+else
+    openssl_src_dir = external_subprojects_dir + '/openssl'
+    if run_command('[', '-d', openssl_src_dir, ']').returncode() != 0
+        message('Fetching OpenSSL D bindings from Github...')
+        git_get_requests = run_command(['git', 'clone', 'https://github.com/s-ludwig/openssl.git', openssl_src_dir])
+        if git_get_requests.returncode() != 0
+            error('Unable to fetch OpenSSL bindings.\n' + git_get_requests.stderr())
+        endif
+    endif
+
+    message('Using non-system of OpenSSL D bindings.')
+endif
+openssl_inc = include_directories(openssl_src_dir)
+
+# Try to find system LibEvent bindings, if not found, download
+# a Git copy.
+libevent_src_dir = ''
+if run_command('[', '-d', '/usr/include/d/common/deimos/event2/', ']').returncode() == 0
+    libevent_src_dir = '/usr/include/d/common'
+else
+    libevent_src_dir = external_subprojects_dir + '/libevent'
+    if run_command('[', '-d', libevent_src_dir, ']').returncode() != 0
+        message('Fetching LibEvent bindings from Github...')
+        git_get_requests = run_command(['git', 'clone', 'https://github.com/s-ludwig/libevent.git', libevent_src_dir])
+        if git_get_requests.returncode() != 0
+            error('Unable to fetch LibEvent bindings.\n' + git_get_requests.stderr())
+        endif
+    endif
+
+    message('Using non-system of LibEvent D bindings.')
+endif
+libevent_inc = include_directories(libevent_src_dir)
+
+if meson.get_compiler('d').get_id() == 'llvm'
+    add_global_arguments(['-d-version=VibeLibeventDriver',
+                          '-d-version=Have_openssl'], language : 'd')
+endif
+if meson.get_compiler('d').get_id() == 'dmd'
+    add_global_arguments(['-version=VibeLibeventDriver',
+                          '-version=Have_openssl'], language : 'd')
+endif
+if meson.get_compiler('d').get_id() == 'gnu'
+    error('Vibe.d can not be compiled with GDC at time (2016). Sorry.')
+endif
+
+#
+# Build Targets
+#
+
+# Basic I/O and concurrency primitives, as well as low level utility functions
+vibe_core_lib = library('vibe-core',
+        [vibe_core_src,
+         vibe_crypto_src,
+         vibe_inet_src,
+         vibe_stream_src,
+         vibe_textfilter_src],
+        include_directories: [src_dir, openssl_inc, libevent_inc],
+        install: true,
+        dependencies: [crypto_dep,
+                       ssl_dep,
+                       libevent_dep,
+                       zlib_dep],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-core',
+              libraries: vibe_core_lib,
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Basic I/O and concurrency primitives, as well as low level utility functions of Vibe.'
+)
+
+# Low level utility functionality
+vibe_utils_lib = library('vibe-utils',
+        [vibe_utils_src,
+         vibe_internal_src],
+        include_directories: [src_dir],
+        install: true,
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-utils',
+              libraries: vibe_utils_lib,
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Low level utility functionality of Vibe.'
+)
+
+# Data format and serialization support
+vibe_data_lib = library('vibe-data',
+        [vibe_data_src],
+        include_directories: [src_dir],
+        install: true,
+        link_with: [vibe_utils_lib],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-data',
+              libraries: [vibe_data_lib, vibe_utils_lib],
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Data format and serialization support for Vibe.'
+)
+
+# HTTP server and client implementation and higher level HTTP functionality
+vibe_http_lib = library('vibe-http',
+        [vibe_http_src],
+        include_directories: [src_dir,openssl_inc, libevent_inc],
+        install: true,
+        dependencies: [zlib_dep],
+        link_with: [vibe_core_lib, vibe_data_lib],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-http',
+              libraries: [vibe_http_lib],
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Vibe HTTP server and client implementation and higher level HTTP functionality'
+)
+
+# SMTP client support
+vibe_mail_lib = library('vibe-mail',
+        [vibe_mail_src],
+        include_directories: [src_dir],
+        install: true,
+        link_with: [vibe_core_lib],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-mail',
+              libraries: [vibe_mail_lib],
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Vibe SMTP client support.'
+)
+
+# Diet HTML template system
+vibe_diet_lib = library('vibe-diet',
+        [vibe_diet_src],
+        include_directories: [src_dir],
+        install: true,
+        link_with: [vibe_http_lib],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-diet',
+              libraries: [vibe_diet_lib],
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Vibe Diet HTML template system.'
+)
+
+# MongoDB database client implementation
+vibe_mongodb_lib = library('vibe-mongodb',
+        [vibe_db_mongo_src],
+        include_directories: [src_dir],
+        install: true,
+        link_with: [vibe_http_lib],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-mongodb',
+              libraries: [vibe_mongodb_lib],
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Vibe MongoDB database client implementation.'
+)
+
+# Redis database client implementation
+vibe_redis_lib = library('vibe-redis',
+        [vibe_db_redis_src],
+        include_directories: [src_dir],
+        install: true,
+        link_with: [vibe_http_lib],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-redis',
+              libraries: [vibe_redis_lib],
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Vibe Redis database client implementation.'
+)
+
+# High level web and REST service framework
+vibe_web_lib = library('vibe-web',
+        [vibe_web_src],
+        include_directories: [src_dir],
+        install: true,
+        link_with: [vibe_http_lib, vibe_diet_lib],
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-web',
+              libraries: [vibe_web_lib],
+              subdirs: 'd/vibe',
+              version: project_version,
+              description: 'Vibe high level web and REST service framework.'
+)
+
+#
+# Tests
+#
+vibe_test_exe = executable('vibe_test',
+    [vibe_main_src,
+     vibe_core_src,
+     vibe_crypto_src,
+     vibe_inet_src,
+     vibe_stream_src,
+     vibe_textfilter_src,
+     vibe_utils_src,
+     vibe_internal_src,
+     vibe_data_src,
+     vibe_http_src,
+     vibe_mail_src,
+     vibe_diet_src,
+     vibe_db_mongo_src,
+     vibe_db_redis_src,
+     vibe_web_src],
+    include_directories: [src_dir, openssl_inc, libevent_inc],
+    dependencies: [zlib_dep,
+                   crypto_dep,
+                   ssl_dep,
+                   libevent_dep],
+    d_args: meson.get_compiler('d').unittest_args(),
+    link_args: '-main'
+)
+test('vibe_testsuite', vibe_test_exe)


### PR DESCRIPTION
Hello!
I am going to use Vibe.d in a project which is build using Meson, and also would like to make Vibe.d available in Debian/Ubuntu at some point.

Especially for the latter, we need some more sophisticated build system than Dub currently is. We need to install built software system-wide, generate proper pkgconfig files, allow to inject custom compile flags for the respective D compiler instead of using upstream's settings and most importantly using dependencies that are part of the system exclusively instead of downloading them from the web.

Dub can't do that (bugs filed with nothing happening), but Meson can do that and more.
Other options for this task would have been Automake or CMake, but Meson is much easier to use for this purpose (compiling D code) than the other two. You can find more information about Meson at http://mesonbuild.com/, at time it is being worked on to likely replace Automake in GNOME projects.

The above patch is not 100% complete, I focused on the most important bits:
 * Compile Vibe.d modules as (shared) libraries
 * Install libraries and pkgconfig files for them
 * Install the Vibe source code for other projects to use
 * Add `unittest {}` support by generating a test binary and executing it
 * Find & use system copies of OpenSSL and LibEvent D bindings, if they are not found, automatically download & use a Git copy.

Missing pieces are:
 * Windows support (I have no way to test that, maybe it already works)
 * Options, e.g. disable tests or compile without OpenSSL or switch LibEvent for a different implementation.

This patch can be tested by:
 * Obtaining Meson (`sudo apt install meson`, or just Git-cloning it)
 * Ensure you have at least version `0.34.0` to ensure D support is present
 * Run `mkdir build && cd build`, then run `meson ..`
 * Run `ninja`
(`ninja` is a build-tool similar to make, but parallelized by default and much simpler, it is used to build several bigger projects, like Google Chrome)

Known issues:
 * Since the D compilers at time don't output Make-compliant depfiles (hello LDC, DMD!), or have broken support for it (hello, GDC!) Ninja sometimes doesn't recompile pieces that need rebuilding (e.g. because a template or function has changed) - in that case, a `ninja clean && ninja` can work around that. Aside from that, I am not aware of any issues.

I went for one very large Meson configuration here - if wanted, this can be split up into more, smaller parts.

Thanks for considering this PR!

Cheers,
    Matthias
