### PR TITLE
Test Meson build on the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: d
+dist: trusty
+sudo: true
 
 d:
   # order: latest DMD, oldest DMD, LDC/GDC, remaining DMD versions
@@ -28,10 +30,13 @@ matrix:
     - d: ldc-1.0.0
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
 
+before_script:
+ - sudo add-apt-repository -y ppa:ximion/tests
+ - sudo apt-get update
+ - sudo apt-get install -y ninja-build libevent-dev
+
 script: ./travis-ci.sh
 
 services:
   - mongodb
   - redis-server
-
-sudo: false

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -24,3 +24,15 @@ if [ ${RUN_TEST=1} -eq 1 ]; then
         (cd tests/$ex && dub --compiler=$DC && dub clean)
     done
 fi
+
+# Test the Meson build system
+git clone --depth 4 https://github.com/mesonbuild/meson.git meson-src
+cd meson-src
+python3 setup.py build
+cd ..
+
+mkdir build && cd build
+../meson-src/meson.py -Derrorlogs=true ..
+ninja
+ninja test
+DESTDIR=/tmp/installtest ninja install


### PR DESCRIPTION
Hi!
Follow-up to https://github.com/rejectedsoftware/vibe.d/pull/1574: I quickly made the CI test Meson builds as well.
The problem with this is that we can't continue to do rootless builds, since Travis' environment is super ancient and we need a Ninja version > 1.6. There is an open feature request at Travis for this, since Ninja is required to build Chromium as well, but nothing happened there as well.

This change in the environment apparently also breaks the tests, I am working on fixing this, but since I don't know the testsuite well it's a bit difficult.

Also, for some reason DMD fails with `Error: unrecognized file extension 30` on some files, I have no idea why yet.

So, this PR is not really for merging yet but rather a "how to probably do it" :-)
That DMD thing looks like a DMD bug or an issue in the Meson settings for DMD, which needs investigating.
