### PR TITLE
Pass -lz when compiling with GDC

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -59,6 +59,7 @@ subPackage {
 	sourceFiles "lib/win-amd64/libeay32.lib" "lib/win-amd64/ssleay32.lib" platform="windows-x86_64"
 	sourcePaths "source/vibe/core" "source/vibe/crypto" "source/vibe/inet" "source/vibe/stream" "source/vibe/textfilter"
 	libs "z" platform="ldc"
+	libs "z" platform="gdc"
 	copyFiles "lib/win-i386/libeay32.dll" "lib/win-i386/ssleay32.dll" platform="windows-x86"
 	copyFiles "lib/win-amd64/libeay32.dll" "lib/win-amd64/ssleay32.dll" platform="windows-x86_64"
 	


### PR DESCRIPTION
Compiling vibe.d projects fails with undefined references to zlib with gdc (Debian 6.2.0-10) 6.2.0 20161027