### PR TITLE
Switch to std.experimental.allocator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ d:
   # slower tham DMD, so they should be started early), while still
   # catching most DMD version related build failures early
   - dmd-2.072.0
-  - dmd-2.068.2
   - ldc-1.0.0
-  - ldc-0.17.0
   - dmd-2.071.2
   - dmd-2.070.2
   - dmd-2.069.2
@@ -24,8 +22,6 @@ env:
 
 matrix:
   exclude:
-    - d: ldc-0.17.0
-      env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
     - d: ldc-1.0.0
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
   allow_failures:

--- a/core/vibe/core/concurrency.d
+++ b/core/vibe/core/concurrency.d
@@ -17,7 +17,7 @@ import std.typetuple;
 import std.variant;
 import std.string;
 import vibe.core.task;
-import vibe.utils.memory;
+import vibe.internal.allocator;
 import vibe.internal.meta.traits : StripHeadConst;
 
 public import std.concurrency;
@@ -1080,6 +1080,8 @@ template isCopyable(T)
 	value.
 */
 struct Future(T) {
+	import vibe.internal.freelistref : FreeListRef;
+
 	private {
 		FreeListRef!(shared(T)) m_result;
 		Task m_task;
@@ -1131,6 +1133,8 @@ struct Future(T) {
 Future!(StripHeadConst!(ReturnType!CALLABLE)) async(CALLABLE, ARGS...)(CALLABLE callable, ARGS args)
 	if (is(typeof(callable(args)) == ReturnType!CALLABLE))
 {
+	import vibe.internal.freelistref : FreeListRef;
+
 	import vibe.core.core;
 	import std.functional : toDelegate;
 

--- a/core/vibe/core/connectionpool.d
+++ b/core/vibe/core/connectionpool.d
@@ -12,7 +12,7 @@ import vibe.core.driver;
 
 import core.thread;
 import vibe.core.sync;
-import vibe.utils.memory;
+import vibe.internal.freelistref;
 
 /**
 	Generic connection pool class.

--- a/core/vibe/core/drivers/libevent2_tcp.d
+++ b/core/vibe/core/drivers/libevent2_tcp.d
@@ -15,7 +15,7 @@ public import vibe.core.core;
 import vibe.core.log;
 import vibe.core.drivers.libevent2;
 import vibe.core.drivers.utils;
-import vibe.utils.memory;
+import vibe.internal.freelistref;
 
 import deimos.event2.buffer;
 import deimos.event2.bufferevent;

--- a/core/vibe/core/stream.d
+++ b/core/vibe/core/stream.d
@@ -11,8 +11,6 @@
 */
 module vibe.core.stream;
 
-import vibe.utils.memory : FreeListRef;
-
 import core.time;
 import std.algorithm;
 import std.conv;
@@ -111,8 +109,11 @@ interface OutputStream {
 
 	protected final void writeDefault(InputStream stream, ulong nbytes = 0)
 	{
+		import vibe.internal.allocator : dispose, make, theAllocator;
+
 		static struct Buffer { ubyte[64*1024] bytes = void; }
-		auto bufferobj = FreeListRef!(Buffer, false)();
+		auto bufferobj = theAllocator.make!Buffer;
+		scope (exit) theAllocator.dispose(bufferobj);
 		auto buffer = bufferobj.bytes[];
 
 		//logTrace("default write %d bytes, empty=%s", nbytes, stream.empty);

--- a/core/vibe/core/sync.d
+++ b/core/vibe/core/sync.d
@@ -123,7 +123,6 @@ class LocalTaskSemaphore
 	// requires a queue
 	import std.container.binaryheap;
 	import std.container.array;
-	import vibe.utils.memory;
 
 	private {
 		struct Waiter {

--- a/core/vibe/internal/allocator.d
+++ b/core/vibe/internal/allocator.d
@@ -1,0 +1,9 @@
+module vibe.internal.allocator;
+
+public import std.experimental.allocator;
+public import std.experimental.allocator.building_blocks.allocator_list;
+public import std.experimental.allocator.building_blocks.null_allocator;
+public import std.experimental.allocator.building_blocks.region;
+public import std.experimental.allocator.building_blocks.stats_collector;
+public import std.experimental.allocator.gc_allocator;
+public import std.experimental.allocator.mallocator;

--- a/core/vibe/internal/freelistref.d
+++ b/core/vibe/internal/freelistref.d
@@ -1,0 +1,222 @@
+/**
+	Utility functions for memory management
+
+	Note that this module currently is a big sand box for testing allocation related stuff.
+	Nothing here, including the interfaces, is final but rather a lot of experimentation.
+
+	Copyright: © 2012-2013 RejectedSoftware e.K.
+	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
+	Authors: Sönke Ludwig
+*/
+module vibe.internal.freelistref;
+
+import vibe.internal.allocator;
+import vibe.internal.meta.traits : synchronizedIsNothrow;
+
+import core.exception : OutOfMemoryError;
+import core.stdc.stdlib;
+import core.memory;
+import std.conv;
+import std.exception : enforceEx;
+import std.traits;
+import std.algorithm;
+
+
+struct FreeListObjectAlloc(T, bool USE_GC = true, bool INIT = true, EXTRA = void)
+{
+	enum ElemSize = AllocSize!T;
+	enum ElemSlotSize = max(AllocSize!T + AllocSize!EXTRA, Slot.sizeof);
+
+	static if( is(T == class) ){
+		alias TR = T;
+	} else {
+		alias TR = T*;
+	}
+
+	struct Slot { Slot* next; }
+
+	private static Slot* s_firstFree;
+
+	static TR alloc(ARGS...)(ARGS args)
+	{
+		void[] mem;
+		if (s_firstFree !is null) {
+			auto ret = s_firstFree;
+			s_firstFree = s_firstFree.next;
+			ret.next = null;
+			mem = (cast(void*)ret)[0 .. ElemSize];
+		} else {
+			//logInfo("alloc %s/%d", T.stringof, ElemSize);
+			mem = Mallocator.instance.allocate(ElemSlotSize);
+			static if( hasIndirections!T ) GC.addRange(mem.ptr, ElemSlotSize);
+		}
+
+		static if (INIT) return cast(TR)internalEmplace!(Unqual!T)(mem, args); // FIXME: this emplace has issues with qualified types, but Unqual!T may result in the wrong constructor getting called.
+		else return cast(TR)mem.ptr;
+	}
+
+	static void free(TR obj)
+	{
+		static if (INIT) {
+			scope (failure) assert(0, "You shouldn't throw in destructors");
+			auto objc = obj;
+			static if (is(TR == T*)) .destroy(*objc);//typeid(T).destroy(cast(void*)obj);
+			else .destroy(objc);
+		}
+
+		auto sl = cast(Slot*)obj;
+		sl.next = s_firstFree;
+		s_firstFree = sl;
+		//static if( hasIndirections!T ) GC.removeRange(cast(void*)obj);
+		//Mallocator.instance.deallocate((cast(void*)obj)[0 .. ElemSlotSize]);
+	}
+}
+
+
+template AllocSize(T)
+{
+	static if (is(T == class)) {
+		// workaround for a strange bug where AllocSize!SSLStream == 0: TODO: dustmite!
+		enum dummy = T.stringof ~ __traits(classInstanceSize, T).stringof;
+		enum AllocSize = __traits(classInstanceSize, T);
+	} else {
+		enum AllocSize = T.sizeof;
+	}
+}
+
+struct FreeListRef(T, bool INIT = true)
+{
+	alias ObjAlloc = FreeListObjectAlloc!(T, true, INIT, int);
+	enum ElemSize = AllocSize!T;
+
+	static if( is(T == class) ){
+		alias TR = T;
+	} else {
+		alias TR = T*;
+	}
+
+	private TR m_object;
+	private size_t m_magic = 0x1EE75817; // workaround for compiler bug
+
+	static FreeListRef opCall(ARGS...)(ARGS args)
+	{
+		//logInfo("refalloc %s/%d", T.stringof, ElemSize);
+		FreeListRef ret;
+		ret.m_object = ObjAlloc.alloc(args);
+		ret.refCount = 1;
+		return ret;
+	}
+
+	~this()
+	{
+		//if( m_object ) logInfo("~this!%s(): %d", T.stringof, this.refCount);
+		//if( m_object ) logInfo("ref %s destructor %d", T.stringof, refCount);
+		//else logInfo("ref %s destructor %d", T.stringof, 0);
+		clear();
+		m_magic = 0;
+		m_object = null;
+	}
+
+	this(this)
+	{
+		checkInvariants();
+		if( m_object ){
+			//if( m_object ) logInfo("this!%s(this): %d", T.stringof, this.refCount);
+			this.refCount++;
+		}
+	}
+
+	void opAssign(FreeListRef other)
+	{
+		clear();
+		m_object = other.m_object;
+		if( m_object ){
+			//logInfo("opAssign!%s(): %d", T.stringof, this.refCount);
+			refCount++;
+		}
+	}
+
+	void clear()
+	{
+		checkInvariants();
+		if (m_object) {
+			if (--this.refCount == 0)
+				ObjAlloc.free(m_object);
+		}
+
+		m_object = null;
+		m_magic = 0x1EE75817;
+	}
+
+	@property const(TR) get() const { checkInvariants(); return m_object; }
+	@property TR get() { checkInvariants(); return m_object; }
+	alias get this;
+
+	private @property ref int refCount()
+	const {
+		auto ptr = cast(ubyte*)cast(void*)m_object;
+		ptr += ElemSize;
+		return *cast(int*)ptr;
+	}
+
+	private void checkInvariants()
+	const {
+		assert(m_magic == 0x1EE75817);
+		assert(!m_object || refCount > 0);
+	}
+}
+
+
+/// See issue #14194
+private T internalEmplace(T, Args...)(void[] chunk, auto ref Args args)
+	if (is(T == class))
+in {
+	import std.string, std.format;
+	assert(chunk.length >= T.sizeof,
+		   format("emplace: Chunk size too small: %s < %s size = %s",
+			  chunk.length, T.stringof, T.sizeof));
+	assert((cast(size_t) chunk.ptr) % T.alignof == 0,
+		   format("emplace: Misaligned memory block (0x%X): it must be %s-byte aligned for type %s", chunk.ptr, T.alignof, T.stringof));
+
+} body {
+	enum classSize = __traits(classInstanceSize, T);
+	auto result = cast(T) chunk.ptr;
+
+	// Initialize the object in its pre-ctor state
+	static if (__VERSION__ < 2071)
+		chunk[0 .. classSize] = typeid(T).init[];
+	else
+		chunk[0 .. classSize] = typeid(T).initializer[]; // Avoid deprecation warning
+
+	// Call the ctor if any
+	static if (is(typeof(result.__ctor(args))))
+	{
+		// T defines a genuine constructor accepting args
+		// Go the classic route: write .init first, then call ctor
+		result.__ctor(args);
+	}
+	else
+	{
+		static assert(args.length == 0 && !is(typeof(&T.__ctor)),
+				"Don't know how to initialize an object of type "
+				~ T.stringof ~ " with arguments " ~ Args.stringof);
+	}
+	return result;
+}
+
+/// Dittor
+private auto internalEmplace(T, Args...)(void[] chunk, auto ref Args args)
+	if (!is(T == class))
+in {
+	import std.string, std.format;
+	assert(chunk.length >= T.sizeof,
+		   format("emplace: Chunk size too small: %s < %s size = %s",
+			  chunk.length, T.stringof, T.sizeof));
+	assert((cast(size_t) chunk.ptr) % T.alignof == 0,
+		   format("emplace: Misaligned memory block (0x%X): it must be %s-byte aligned for type %s", chunk.ptr, T.alignof, T.stringof));
+
+} body {
+	return emplace(cast(T*)chunk.ptr, args);
+}
+
+private void logDebug_(ARGS...)(string msg, ARGS args) {}

--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -1328,8 +1328,8 @@ struct BsonSerializer {
 
 	this(ubyte[] buffer)
 	{
-		import vibe.utils.memory;
-		m_dst = AllocAppender!(ubyte[])(defaultAllocator(), buffer);
+		import vibe.internal.utilallocator;
+		m_dst = AllocAppender!(ubyte[])(processAllocator(), buffer);
 	}
 
 	@disable this(this);

--- a/http/vibe/http/common.d
+++ b/http/vibe/http/common.d
@@ -15,7 +15,7 @@ import vibe.inet.message;
 import vibe.stream.operations;
 import vibe.textfilter.urlencode : urlEncode, urlDecode;
 import vibe.utils.array;
-import vibe.utils.memory;
+import vibe.internal.allocator;
 import vibe.utils.string;
 
 import std.algorithm;
@@ -437,7 +437,7 @@ final class ChunkedOutputStream : OutputStream {
 		ChunkExtensionCallback m_chunkExtensionCallback = null;
 	}
 
-	this(OutputStream stream, Allocator alloc = defaultAllocator())
+	this(OutputStream stream, IAllocator alloc = theAllocator())
 	{
 		m_out = stream;
 		m_buffer = AllocAppender!(ubyte[])(alloc);

--- a/inet/vibe/inet/message.d
+++ b/inet/vibe/inet/message.d
@@ -11,7 +11,7 @@ import vibe.core.log;
 import vibe.core.stream;
 import vibe.stream.operations;
 import vibe.utils.array;
-import vibe.utils.memory;
+import vibe.internal.allocator;
 import vibe.utils.string;
 import vibe.utils.dictionarylist;
 
@@ -32,7 +32,7 @@ import std.string;
 		alloc = Custom allocator to use for allocating strings
 		rfc822_compatible = Flag indicating that duplicate fields should be merged using a comma
 */
-void parseRFC5322Header(InputStream input, ref InetHeaderMap dst, size_t max_line_length = 1000, Allocator alloc = defaultAllocator(), bool rfc822_compatible = true)
+void parseRFC5322Header(InputStream input, ref InetHeaderMap dst, size_t max_line_length = 1000, IAllocator alloc = processAllocator(), bool rfc822_compatible = true)
 {
 	string hdr, hdrvalue;
 

--- a/stream/vibe/stream/memory.d
+++ b/stream/vibe/stream/memory.d
@@ -9,7 +9,7 @@ module vibe.stream.memory;
 
 import vibe.core.stream;
 import vibe.utils.array;
-import vibe.utils.memory;
+import vibe.internal.allocator;
 
 import std.algorithm;
 import std.array;
@@ -25,7 +25,7 @@ final class MemoryOutputStream : OutputStream {
 		AllocAppender!(ubyte[]) m_destination;
 	}
 
-	this(Allocator alloc = defaultAllocator())
+	this(IAllocator alloc = processAllocator())
 	{
 		m_destination = AllocAppender!(ubyte[])(alloc);
 	}

--- a/stream/vibe/stream/multicast.d
+++ b/stream/vibe/stream/multicast.d
@@ -9,7 +9,6 @@ module vibe.stream.multicast;
 
 import vibe.core.core;
 import vibe.core.stream;
-import vibe.utils.memory;
 
 import std.exception;
 

--- a/stream/vibe/stream/openssl.d
+++ b/stream/vibe/stream/openssl.d
@@ -336,12 +336,12 @@ final class OpenSSLStream : TLSStream {
 	private void setClientALPN(string[] alpn_list)
 	{
 		logDebug("SetClientALPN: ", alpn_list);
-		import vibe.utils.memory : allocArray, freeArray, manualAllocator;
+		import vibe.internal.allocator : dispose, makeArray, processAllocator;
 		ubyte[] alpn;
 		size_t len;
 		foreach (string alpn_val; alpn_list)
 			len += alpn_val.length + 1;
-		alpn = allocArray!ubyte(manualAllocator(), len);
+		alpn = processAllocator.makeArray!ubyte(len);
 
 		size_t i;
 		foreach (string alpn_val; alpn_list)
@@ -355,7 +355,7 @@ final class OpenSSLStream : TLSStream {
 		static if (haveALPN)
 			SSL_set_alpn_protos(m_ssl, cast(const char*) alpn.ptr, cast(uint) len);
 
-		freeArray(manualAllocator(), alpn);
+		processAllocator.dispose(alpn);
 	}
 }
 

--- a/stream/vibe/stream/tls.d
+++ b/stream/vibe/stream/tls.d
@@ -146,13 +146,13 @@ auto createTLSStreamFL(Stream underlying, TLSContext ctx, TLSStreamState state, 
 	// will have to semantically analyse it and subsequently will import the TLS
 	// implementation headers.
 	version (OpenSSL) {
-		import vibe.utils.memory;
+		import vibe.internal.freelistref;
 		import vibe.stream.openssl;
 		static assert(AllocSize!TLSStream > 0);
 		return FreeListRef!OpenSSLStream(underlying, cast(OpenSSLContext)ctx,
 										 state, peer_name, peer_address);
 	} else version (Botan) {
-		import vibe.utils.memory;
+		import vibe.internal.freelistref;
 		import vibe.stream.botan;
 		return FreeListRef!BotanTLSStream(cast(ConnectionStream) underlying, cast(BotanTLSContext) ctx, state, peer_name, peer_address);
 	} else assert(false, "No TLS support compiled in (VibeNoTLS)");

--- a/stream/vibe/stream/zlib.d
+++ b/stream/vibe/stream/zlib.d
@@ -9,7 +9,6 @@ module vibe.stream.zlib;
 
 import vibe.core.stream;
 import vibe.utils.array;
-import vibe.utils.memory;
 
 import std.algorithm;
 import std.exception;

--- a/utils/vibe/internal/utilallocator.d
+++ b/utils/vibe/internal/utilallocator.d
@@ -1,0 +1,3 @@
+module vibe.internal.utilallocator;
+
+public import std.experimental.allocator;

--- a/utils/vibe/utils/memory.d
+++ b/utils/vibe/utils/memory.d
@@ -8,6 +8,7 @@
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */
+deprecated("Use the memutils package or std.experimental.allocator instead.")
 module vibe.utils.memory;
 
 import vibe.internal.meta.traits : synchronizedIsNothrow;
@@ -187,8 +188,10 @@ final class DebugAllocator : Allocator {
 
 	this(Allocator base_allocator) nothrow
 	{
+		import std.experimental.allocator : allocatorObject;
+		import std.experimental.allocator.mallocator : Mallocator;
 		m_baseAlloc = base_allocator;
-		m_blocks = HashMap!(void*, size_t)(manualAllocator());
+		m_blocks = HashMap!(void*, size_t)(Mallocator.instance.allocatorObject);
 	}
 
 	@property size_t allocatedBlockCount() const { return m_blocks.length; }
@@ -200,7 +203,8 @@ final class DebugAllocator : Allocator {
 		auto ret = m_baseAlloc.alloc(sz);
 		assert(ret.length == sz, "base.alloc() returned block with wrong size.");
 		assert(m_blocks.getNothrow(ret.ptr, size_t.max) == size_t.max, "base.alloc() returned block that is already allocated.");
-		m_blocks[ret.ptr] = sz;
+		try m_blocks[ret.ptr] = sz;
+		catch (Exception e) assert(false, e.msg);
 		m_bytes += sz;
 		if( m_bytes > m_maxBytes ){
 			m_maxBytes = m_bytes;
@@ -219,7 +223,8 @@ final class DebugAllocator : Allocator {
 		assert(ret.ptr is mem.ptr || m_blocks.getNothrow(ret.ptr, size_t.max) == size_t.max, "base.realloc() returned block that is already allocated.");
 		m_bytes -= sz;
 		m_blocks.remove(mem.ptr);
-		m_blocks[ret.ptr] = new_size;
+		try m_blocks[ret.ptr] = new_size;
+		catch (Exception e) assert(false, e.msg);
 		m_bytes += new_size;
 		return ret;
 	}

--- a/utils/vibe/utils/string.d
+++ b/utils/vibe/utils/string.d
@@ -10,7 +10,7 @@ module vibe.utils.string;
 public import std.string;
 
 import vibe.utils.array;
-import vibe.utils.memory;
+import vibe.internal.utilallocator;
 
 import std.algorithm;
 import std.array;
@@ -186,7 +186,7 @@ sizediff_t matchBracket(const(char)[] str, bool nested = true)
 }
 
 /// Same as std.string.format, just using an allocator.
-string formatAlloc(ARGS...)(Allocator alloc, string fmt, ARGS args)
+string formatAlloc(ARGS...)(IAllocator alloc, string fmt, ARGS args)
 {
 	auto app = AllocAppender!string(alloc);
 	formattedWrite(&app, fmt, args);


### PR DESCRIPTION
This deprecates the included allocator/memory module in favor of the one contained in Phobos.