### PR TITLE
fix #716 (Add partial content with range)

### DIFF
--- a/http/vibe/http/fileserver.d
+++ b/http/vibe/http/fileserver.d
@@ -13,7 +13,6 @@ import vibe.http.server;
 import vibe.inet.message;
 import vibe.inet.mimetypes;
 import vibe.inet.url;
-import vibe.stream.counting;
 
 import std.conv;
 import std.datetime;
@@ -403,7 +402,7 @@ private void sendFileImpl(scope HTTPServerRequest req, scope HTTPServerResponse 
 
 	if (prange) {
 		fil.seek(rangeStart);
-		res.bodyWriter.write(new LimitedInputStream(fil, rangeEnd - rangeStart + 1));
+		res.bodyWriter.write(fil, rangeEnd - rangeStart + 1);
 		logTrace("partially sent file %d-%d, %s!", rangeStart, rangeEnd, res.headers["Content-Type"]);
 	} else {
 		if (pce && !encodedFilepath.length)

--- a/http/vibe/http/fileserver.d
+++ b/http/vibe/http/fileserver.d
@@ -18,6 +18,7 @@ import std.conv;
 import std.datetime;
 import std.digest.md;
 import std.string;
+import std.algorithm;
 
 
 /**
@@ -318,6 +319,8 @@ private void sendFileImpl(scope HTTPServerRequest req, scope HTTPServerResponse 
 
 	if (prange) {
 		auto range = (*prange).chompPrefix("bytes=");
+		if (range.canFind(','))
+			throw new HTTPStatusException(HTTPStatus.notImplemented);
 		auto s = range.split("-");
 		// https://tools.ietf.org/html/rfc7233
 		// Range can be in form "-\d", "\d-" or "\d-\d"

--- a/http/vibe/http/fileserver.d
+++ b/http/vibe/http/fileserver.d
@@ -13,6 +13,7 @@ import vibe.http.server;
 import vibe.inet.message;
 import vibe.inet.mimetypes;
 import vibe.inet.url;
+import vibe.stream.counting;
 
 import std.conv;
 import std.datetime;
@@ -311,7 +312,41 @@ private void sendFileImpl(scope HTTPServerRequest req, scope HTTPServerResponse 
 	if ("Content-Encoding" in res.headers && isCompressedFormat(mimetype))
 		res.headers.remove("Content-Encoding");
 	res.headers["Content-Type"] = mimetype;
-	res.headers["Content-Length"] = to!string(dirent.size);
+	res.headers.addField("Accept-Ranges", "bytes");
+	ulong rangeStart = 0;
+	ulong rangeEnd = 0;
+	auto prange = "Range" in req.headers;
+
+	if (prange) {
+		auto range = (*prange).chompPrefix("bytes=");
+		auto s = range.split("-");
+		// https://tools.ietf.org/html/rfc7233
+		// Range can be in form "-\d", "\d-" or "\d-\d"
+		if (s[0].length) {
+			rangeStart = s[0].to!ulong;
+			rangeEnd = s[1].length ? s[1].to!ulong : dirent.size;
+		} else if (s[1].length) {
+			rangeEnd = dirent.size;
+			auto len = s[1].to!ulong;
+			if (len >= rangeEnd)
+				rangeStart = 0;
+			else
+				rangeStart = rangeEnd - len;
+		} else {
+			throw new HTTPStatusException(HTTPStatus.badRequest);
+		}
+		if (rangeEnd > dirent.size)
+			rangeEnd = dirent.size;
+		if (rangeStart > rangeEnd)
+			rangeStart = rangeEnd;
+		if (rangeEnd)
+			rangeEnd--; // End is inclusive, so one less than length
+		// potential integer overflow with rangeEnd - rangeStart == size_t.max is intended. This only happens with empty files, the + 1 will then put it back to 0
+		res.headers["Content-Length"] = to!string(rangeEnd - rangeStart + 1);
+		res.headers["Content-Range"] = "bytes %s-%s/%s".format(rangeStart < rangeEnd ? rangeStart : rangeEnd, rangeEnd, dirent.size);
+		res.statusCode = HTTPStatus.partialContent;
+	} else
+		res.headers["Content-Length"] = dirent.size.to!string;
 
 	// check for already encoded file if configured
 	string encodedFilepath;
@@ -366,8 +401,14 @@ private void sendFileImpl(scope HTTPServerRequest req, scope HTTPServerResponse 
 	}
 	scope(exit) fil.close();
 
-	if (pce && !encodedFilepath.length)
-		res.bodyWriter.write(fil);
-	else res.writeRawBody(fil);
-	logTrace("sent file %d, %s!", fil.size, res.headers["Content-Type"]);
+	if (prange) {
+		fil.seek(rangeStart);
+		res.bodyWriter.write(new LimitedInputStream(fil, rangeEnd - rangeStart + 1));
+		logTrace("partially sent file %d-%d, %s!", rangeStart, rangeEnd, res.headers["Content-Type"]);
+	} else {
+		if (pce && !encodedFilepath.length)
+			res.bodyWriter.write(fil);
+		else res.writeRawBody(fil);
+		logTrace("sent file %d, %s!", fil.size, res.headers["Content-Type"]);
+	}
 }


### PR DESCRIPTION
Mostly based on https://github.com/rejectedsoftware/vibe.d/issues/716#issuecomment-220606604

Changes to that comment: added `-[X]` format and sending partialContent status code. Also some cleaner code and checks against bad requests.

Not sure how to add an automatic test but I did manually test it locally using this very simple file server in chrome and firefox:

```d
import vibe.http.server;
import vibe.http.fileserver;

shared static this()
{
	auto settings = new HTTPServerSettings;
	settings.port = 10716;
	listenHTTP(settings, serveStaticFiles("data"));
}
```

My aim was only fixing media streams (audio & video + seeking), but pausing downloads and resuming also works now.