### PR TITLE
Respect explicitly set Content-Type in sendFile

### DIFF
--- a/http/vibe/http/fileserver.d
+++ b/http/vibe/http/fileserver.d
@@ -307,11 +307,15 @@ private void sendFileImpl(scope HTTPServerRequest req, scope HTTPServerResponse 
 		}
 	}
 
-	auto mimetype = getMimeTypeForFile(pathstr);
+	auto mimetype = res.headers.get("Content-Type", getMimeTypeForFile(pathstr));
+
 	// avoid double-compression
 	if ("Content-Encoding" in res.headers && isCompressedFormat(mimetype))
 		res.headers.remove("Content-Encoding");
-	res.headers["Content-Type"] = mimetype;
+
+	if (!("Content-Type" in res.headers))
+		res.headers["Content-Type"] = mimetype;
+
 	res.headers.addField("Accept-Ranges", "bytes");
 	ulong rangeStart = 0;
 	ulong rangeEnd = 0;


### PR DESCRIPTION
Currently when using **sendFile**, the *Content-Type* header is automatically set based on file extension. While this default behaviour is fine, the problem is that the header is overwritten if already explicitly set.

In my case, files are not stored using any extension, so all files are treated as *application/octet-stream*. I have the correct media type stored elsewhere, and it would be nice if I could manually specify this, without having the header overwritten internally.