### PR TITLE
Propagate XHR error to on_error in JS RestInterface

### DIFF
--- a/web/vibe/web/internal/rest/jsclient.d
+++ b/web/vibe/web/internal/rest/jsclient.d
@@ -139,6 +139,9 @@ class JSRestClientSettings
 			fout.put("};\n");
 		}
 
+		// error handling
+		fout.put(`xhr.onerror = function (e) { if (on_error) on_error(e); else console.log("XHR request failed"); }\n`);
+
 		// header parameters
 		foreach (p; route.headerParameters)
 			fout.formattedWrite("xhr.setRequestHeader(%s, %s);\n", Json(p.fieldName), p.name);


### PR DESCRIPTION
Allow using the on_error function also when the XHR request fails completely (e.g. when the host is not available).
This is useful when needing feedback on whether or not the XHR request was successful or not.

If there's anything I can improve, please let me know!