### PR TITLE
Fix #1648 - ignore authorization in RestInterfaceClient

### DIFF
--- a/web/vibe/web/internal/rest/common.d
+++ b/web/vibe/web/internal/rest/common.d
@@ -250,7 +250,9 @@ import std.meta : anySatisfy, Filter;
 
 		StaticRoute[routeCount] ret;
 
-		alias AUTHTP = AuthInfo!TImpl;
+		static if (is(TImpl == class)) {
+			alias AUTHTP = AuthInfo!TImpl;
+		}
 
 		foreach (fi, func; RouteFunctions) {
 			StaticRoute route;
@@ -290,9 +292,14 @@ import std.meta : anySatisfy, Filter;
 				}
 
 				// determine parameter source/destination
-				if (is(PT == AUTHTP)) {
-					pi.kind = ParameterKind.auth;
-				} else if (IsAttributedParameter!(func, pname)) {
+				static if (is(TImpl == class)) {
+					if (is(PT == AUTHTP)) {
+						pi.kind = ParameterKind.auth;
+					}
+				}
+
+				if (pi.kind == ParameterKind.auth) {}
+				else if (IsAttributedParameter!(func, pname)) {
 					pi.kind = ParameterKind.attributed;
 				} else static if (anySatisfy!(mixin(CompareParamName.Name), WPAT)) {
 					alias PWPAT = Filter!(mixin(CompareParamName.Name), WPAT);


### PR DESCRIPTION
Not sure if this is the acceptable way to handle REST API with @requiresAuth on the client side, but it seems to solve the problem for me - server side still requires authorization and rest client just ignores this attribute.