### PR TITLE
Support for named tuple de/serialization as associative arrays

### DIFF
--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -1176,7 +1176,7 @@ unittest {
 //	assert(serializeToBson(const A(123)) == Bson(123));
 //	assert(serializeToBson(A(123))       == Bson(123));
 
-	static struct B { int value; static B fromBson(Bson val) { return B(val.get!int); } Bson toBson() const { return Bson(value); } Json toJson() { return Json(); } }
+	static struct B { int value; static B fromBson(Bson val) { return B(val.get!int); } @safe Bson toBson() const { return Bson(value); } Json toJson() { return Json(); } }
 	static assert(!isStringSerializable!B && !isJsonSerializable!B && isBsonSerializable!B);
 	static assert(!isStringSerializable!(const(B)) && !isJsonSerializable!(const(B)) && !isBsonSerializable!(const(B)));
 	assert(serializeToBson(const B(123)) == Bson(123));
@@ -1195,7 +1195,7 @@ unittest {
 	assert(serializeToBson(D(123))       == serializeToBson(["value": 123]));
 
 	// test if const(class) is serializable
-	static class E { int value; this(int v) { value = v; } static E fromBson(Bson val) { return new E(val.get!int); } Bson toBson() const { return Bson(value); } Json toJson() { return Json(); } }
+	static class E { int value; this(int v) { value = v; } static E fromBson(Bson val) { return new E(val.get!int); } @safe Bson toBson() const { return Bson(value); } Json toJson() { return Json(); } }
 	static assert(!isStringSerializable!E && !isJsonSerializable!E && isBsonSerializable!E);
 	static assert(!isStringSerializable!(const(E)) && !isJsonSerializable!(const(E)) && !isBsonSerializable!(const(E)));
 	assert(serializeToBson(new const E(123)) == Bson(123));

--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -1424,7 +1424,7 @@ T deserializeJson(T, R)(R input)
 }
 
 unittest {
-	static struct A { int value; static A fromJson(Json val) { return A(val.get!int); } Json toJson() const { return Json(value); } }
+	static struct A { int value; static A fromJson(Json val) { return A(val.get!int); } @safe Json toJson() const { return Json(value); } }
 	static struct C { int value; static C fromString(string val) { return C(val.to!int); } string toString() const { return value.to!string; } }
 	static struct D { int value; }
 


### PR DESCRIPTION
This is an initial proposal for named tuple de/serialization support as associative arrays. Also part of this change is the deserialization support for the existing tuple serialization as standard arrays. Finally added a couple of @safe statements to silent a couple of warnings when running the "dub test vibe-d:data".