### PR TITLE
Support deserialization of AA whose key type is string-based enum

### DIFF
--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -1557,6 +1557,24 @@ unittest { // const and mutable json
 	assert(serializeToJson(k) == Json(2));
 }
 
+unittest { // issue #1660 - deserialize AA whose key type is string-based enum
+	enum Foo: string
+	{
+		Bar = "bar",
+		Buzz = "buzz"
+	}
+
+	struct S {
+		int[Foo] f;
+	}
+
+	const s = S([Foo.Bar: 2000]);
+	assert(serializeToJson(s)["f"] == Json([Foo.Bar: Json(2000)]));
+
+	auto j = Json.emptyObject;
+	j["f"] = [Foo.Bar: Json(2000)];
+	assert(deserializeJson!S(j).f == [Foo.Bar: 2000]);
+}
 
 /**
 	Serializer for a plain Json representation.

--- a/data/vibe/data/serialization.d
+++ b/data/vibe/data/serialization.d
@@ -577,7 +577,7 @@ private template deserializeValueImpl(Serializer, alias Policy) {
 			T ret;
 			ser.readDictionary!Traits((name) @safe {
 				TK key;
-				static if (is(TK == string)) key = name;
+				static if (is(TK == string) || (is(TK == enum) && is(OriginalType!TK == string))) key = cast(string)name;
 				else static if (is(TK : real) || is(TK : long) || is(TK == enum)) key = name.to!TK;
 				else static if (isStringSerializable!TK) key = TK.fromString(name);
 				else static assert(false, "Associative array keys must be strings, numbers, enums, or have toString/fromString methods.");

--- a/data/vibe/data/serialization.d
+++ b/data/vibe/data/serialization.d
@@ -577,7 +577,7 @@ private template deserializeValueImpl(Serializer, alias Policy) {
 			T ret;
 			ser.readDictionary!Traits((name) @safe {
 				TK key;
-				static if (is(TK == string) || (is(TK == enum) && is(OriginalType!TK == string))) key = cast(string)name;
+				static if (is(TK == string) || (is(TK == enum) && is(OriginalType!TK == string))) key = cast(TK)name;
 				else static if (is(TK : real) || is(TK : long) || is(TK == enum)) key = name.to!TK;
 				else static if (isStringSerializable!TK) key = TK.fromString(name);
 				else static assert(false, "Associative array keys must be strings, numbers, enums, or have toString/fromString methods.");


### PR DESCRIPTION
It fixes #1660.
I also added a unittest for serializing/deserializing AA whose key type is string-based enum.

I leave the case of AA with `@byName` because AA does not support this attribute yet (in implementation).
