### PR TITLE
vibe.http.session: Allow to remove a field from a session

### DIFF
--- a/http/vibe/http/session.d
+++ b/http/vibe/http/session.d
@@ -93,6 +93,9 @@ struct Session {
 		m_store.set(m_id, key, serialize(value));
 	}
 
+	// Removes a field from a session
+	void remove(string key) @safe { m_store.remove(m_id, key); }
+
 	/**
 		Enables foreach-iteration over all keys of the session.
 	*/
@@ -174,6 +177,9 @@ interface SessionStore {
 	/// Determines if a certain session key is set.
 	bool isKeySet(string id, string key);
 
+	/// Removes a key from a session
+	void remove(string id, string key);
+
 	/// Terminates the given session.
 	void destroy(string id);
 
@@ -252,6 +258,11 @@ final class MemorySessionStore : SessionStore {
 	bool isKeySet(string id, string key)
 	{
 		return (key in m_sessions[id]) !is null;
+	}
+
+	void remove(string id, string key)
+	{
+		m_sessions[id].remove(key);
 	}
 
 	void destroy(string id)

--- a/redis/vibe/db/redis/sessionstore.d
+++ b/redis/vibe/db/redis/sessionstore.d
@@ -66,6 +66,11 @@ final class RedisSessionStore : SessionStore {
 		return m_db.hexists(id, key);
 	}
 
+	void remove(string id, string key)
+	{
+		m_db.hdel(id, key);
+	}
+
 	void destroy(string id)
 	{
 		m_db.del(id);


### PR DESCRIPTION
Adds the capability to remove a field from a session.
It's named `remove` after the D's [HashMap `remove`](https://dlang.org/spec/hash-map.html#removing_keys)