### PR TITLE
Fix #1673 - safety inference in tree structure of REST API

### DIFF
--- a/data/vibe/data/serialization.d
+++ b/data/vibe/data/serialization.d
@@ -349,7 +349,7 @@ private template serializeValueImpl(Serializer, alias Policy) {
 	static assert(Serializer.isSupportedValueType!string, "All serializers must support string values.");
 	static assert(Serializer.isSupportedValueType!(typeof(null)), "All serializers must support null values.");
 
-	private void serializeValue(T, ATTRIBUTES...)(ref Serializer ser, T value)
+	private void serializeValue(T, ATTRIBUTES...)(ref Serializer ser, T value) @safe
 	{
 		import std.typecons : BitFlags, Nullable, Tuple, Typedef, TypedefType, tuple;
 
@@ -1679,4 +1679,9 @@ unittest {
 	assert(ser == "V(i)(42)", ser);
 	auto deser = deserialize!(TestSerializer, T)(ser);
 	assert(deser == 42);
+}
+
+@safe unittest {
+	static struct Foo { Foo[] foos; }
+	serialize!TestSerializer(Foo());
 }

--- a/data/vibe/data/serialization.d
+++ b/data/vibe/data/serialization.d
@@ -221,7 +221,7 @@ unittest {
 		import std.conv;
 		import std.array;
 
-		static string toRepresentation(T value) {
+		static string toRepresentation(T value) @safe {
 			return to!string(value.x) ~ "x" ~ to!string(value.y);
 		}
 


### PR DESCRIPTION
I solved it by annotating serializeValue method and fixed all unittests so it compiles (with dmd-2.073.0).

There are some more pragma deprecation messages that can be fixed, but I wanted this to be minimal and to see if this is even acceptable.