### PR TITLE
Add support for retrieving the websocket close code/reason

### DIFF
--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -386,8 +386,9 @@ final class WebSocket {
 		Returns the close code sent by the remote end.
 
 		Note if the connection was never opened, is still alive, or was closed
-		locally this value will be 0. If the connection was not closed cleanly by
-		the remote end, this value will be 1006.
+		locally this value will be 0. If no close code was given by the remote
+		end in the close frame, the value will be 1005. If the connection was
+		not closed cleanly by the remote end, this value will be 1006.
 	*/
 	@property short closeCode() { return m_closeCode; }
 
@@ -579,6 +580,9 @@ final class WebSocket {
 				}
 				if(msg.frameOpcode == FrameOpcode.close) {
 					logDebug("Got closing frame (%s)", m_sentCloseFrame);
+
+					// If no close code was passed, we default to 1005
+					this.m_closeCode = 1005;
 
 					// If provided in the frame, attempt to parse the close code/reason
 					if (msg.peek().length >= short.sizeof) {

--- a/http/vibe/http/websockets.d
+++ b/http/vibe/http/websockets.d
@@ -385,16 +385,17 @@ final class WebSocket {
 	/**
 		Returns the close code sent by the remote end.
 
-		Note that this code will only be set if the connection was closed cleanly by
-		the remote end. In all other cases this value will be 0.
+		Note if the connection was never opened, is still alive, or was closed
+		locally this value will be 0. If the connection was not closed cleanly by
+		the remote end, this value will be 1006.
 	*/
 	@property short closeCode() { return m_closeCode; }
 
 	/**
 		Returns the close reason sent by the remote end.
 
-		Note that this reason will only be set if the connection was closed cleanly by
-		the remote end. In all other cases this will be an empty array.
+		Note if the connection was never opened, is still alive, or was closed
+		locally this value will be an empty string.
 	*/
 	@property const(char)[] closeReason() { return m_closeReason; }
 
@@ -603,6 +604,10 @@ final class WebSocket {
 			logDiagnostic("Error while reading websocket message: %s", e.msg);
 			logDiagnostic("Closing connection.");
 		}
+
+		// If no close code was passed, e.g. this was an unclean termination
+		//  of our websocket connection, set the close code to 1006.
+		if (this.m_closeCode == 0) this.m_closeCode = 1006;
 		m_conn.close();
 	}
 


### PR DESCRIPTION
This PR adds support for retrieving a websocket connections close code and reason. Fairly straightforward, but vibe.d's source is all new territory so please advise if something is glaringly wrong or horrible.

The TL;DR implementation;

1. If we receive a close frame with at least enough bytes for a `short`, we read the short in as the close code
2. If the close frame contains more than enough bytes for a `short`, we read the short in as the close code and read the remaining bytes in as a character array for the close reason.

