### PR TITLE
Fix #1549 - Support bodyParam attribute without form parameter name too map the whole body to a single parameter

### DIFF
--- a/examples/rest/source/app.d
+++ b/examples/rest/source/app.d
@@ -353,8 +353,7 @@ unittest
  * However, it makes no sense to have 'ref' or 'out' parameters on
  * body or query parameter, so those are treated as error at compile time.
  *
- * To serialize the entire Json body into one parameter, simply name the
- * parameter "foo"
+ * If no Json fieldname is passed to @bodyParam, the entire Json body is deserialized into the respective field.
  */
 @rootPathFromName
 interface Example6API

--- a/examples/rest/source/app.d
+++ b/examples/rest/source/app.d
@@ -352,6 +352,9 @@ unittest
  * This is to be consistent with the way D 'out' and 'ref' works.
  * However, it makes no sense to have 'ref' or 'out' parameters on
  * body or query parameter, so those are treated as error at compile time.
+ *
+ * To serialize the entire Json body into one parameter, simply name the
+ * parameter "foo"
  */
 @rootPathFromName
 interface Example6API
@@ -373,6 +376,13 @@ interface Example6API
 	// currently serializing passed data as Json and pass them through the body.
 	@bodyParam("myFoo", "parameter")
 	string postConcat(FooType myFoo);
+
+	// If no field name is passed to @bodyParam the entire json object is
+	// serialized into the parameter.
+	// Moreover if only one bodyParameter is present, this is the default
+	// behavior.
+	@bodyParam("obj")
+	string postConcatBody(FooType obj);
 
 	struct FooType {
 		int a;
@@ -413,6 +423,11 @@ override:
 	{
 		import std.conv : to;
 		return to!string(myFoo.a)~myFoo.s~to!string(myFoo.d);
+	}
+
+	string postConcatBody(FooType obj)
+	{
+		return postConcat(obj);
 	}
 }
 
@@ -558,6 +573,11 @@ shared static this()
 			auto api = new RestInterfaceClient!Example6API("http://127.0.0.1:8080");
 			auto answer = api.postAnswer("IDK");
 			assert(answer == "False");
+
+			Example6API.FooType fType = {a: 1, s: "str", d: 3.14};
+			auto expected = "1str3.14";
+			assert(api.postConcat(fType) == expected);
+			assert(api.postConcatBody(fType) == expected);
 		}
 
 		// Example 7 -- Custom JSON response

--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -377,9 +377,6 @@ interface Example6API
 	@bodyParam("obj")
 	string postConcatBody(FooType obj);
 
-	// expects the entire body (by default)
-	string postConcatBody2(FooType obj);
-
 	struct FooType {
 		int a;
 		string s;
@@ -422,11 +419,6 @@ override:
 	}
 
 	string postConcatBody(FooType obj)
-	{
-		return postConcat(obj);
-	}
-
-	string postConcatBody2(FooType obj)
 	{
 		return postConcat(obj);
 	}

--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -373,6 +373,13 @@ interface Example6API
 	@bodyParam("myFoo", "parameter")
 	string postConcat(FooType myFoo);
 
+	// expects the entire body
+	@bodyParam("obj")
+	string postConcatBody(FooType obj);
+
+	// expects the entire body (by default)
+	string postConcatBody2(FooType obj);
+
 	struct FooType {
 		int a;
 		string s;
@@ -412,6 +419,16 @@ override:
 	{
 		import std.conv : to;
 		return to!string(myFoo.a)~myFoo.s~to!string(myFoo.d);
+	}
+
+	string postConcatBody(FooType obj)
+	{
+		return postConcat(obj);
+	}
+
+	string postConcatBody2(FooType obj)
+	{
+		return postConcat(obj);
 	}
 }
 
@@ -544,21 +561,59 @@ void runTests()
 		enum expected = "42fortySomething51.42"; // to!string(51.42) doesn't work at CT
 
 		auto api = new RestInterfaceClient!Example6API("http://127.0.0.1:8080");
-		// First we make sure parameters are transmitted via query.
-		auto res = requestHTTP("http://127.0.0.1:8080/example6_api/concat",
-							   (scope r) {
-						   import vibe.data.json;
-						   r.method = HTTPMethod.POST;
-						   Json obj = Json.emptyObject;
-						   obj["parameter"] = serializeToJson(Example6API.FooType(42, "fortySomething", 51.42));
-						   r.writeJsonBody(obj);
-					   });
+		{
+			// First we make sure parameters are transmitted via query.
+			auto res = requestHTTP("http://127.0.0.1:8080/example6_api/concat",
+								   (scope r) {
+							   import vibe.data.json;
+							   r.method = HTTPMethod.POST;
+							   Json obj = Json.emptyObject;
+							   obj["parameter"] = serializeToJson(Example6API.FooType(42, "fortySomething", 51.42));
+							   r.writeJsonBody(obj);
+						   });
 
-		assert(res.statusCode == 200);
-		assert(res.bodyReader.readAllUTF8() == `"`~expected~`"`);
-		// Then we check that both can communicate together.
-		auto answer = api.postConcat(Example6API.FooType(42, "fortySomething", 51.42));
-		assert(answer == expected);
+			assert(res.statusCode == 200);
+			assert(res.bodyReader.readAllUTF8() == `"`~expected~`"`);
+			// Then we check that both can communicate together.
+			auto answer = api.postConcat(Example6API.FooType(42, "fortySomething", 51.42));
+			assert(answer == expected);
+		}
+
+		// suppling the whole body
+		{
+			// First we make sure parameters are transmitted via query.
+			auto res = requestHTTP("http://127.0.0.1:8080/example6_api/concat_body",
+								   (scope r) {
+							   import vibe.data.json;
+							   r.method = HTTPMethod.POST;
+							   Json obj = serializeToJson(Example6API.FooType(42, "fortySomething", 51.42));
+							   r.writeJsonBody(obj);
+						   });
+
+			assert(res.statusCode == 200);
+			assert(res.bodyReader.readAllUTF8() == `"`~expected~`"`);
+			// Then we check that both can communicate together.
+			auto answer = api.postConcatBody(Example6API.FooType(42, "fortySomething", 51.42));
+			assert(answer == expected);
+		}
+
+		// suppling the whole body (default parameter)
+		{
+			// First we make sure parameters are transmitted via query.
+			auto res = requestHTTP("http://127.0.0.1:8080/example6_api/concat_body2",
+								   (scope r) {
+							   import vibe.data.json;
+							   r.method = HTTPMethod.POST;
+							   Json obj = serializeToJson(Example6API.FooType(42, "fortySomething", 51.42));
+							   r.writeJsonBody(obj);
+						   });
+
+			assert(res.statusCode == 200);
+			assert(res.bodyReader.readAllUTF8() == `"`~expected~`"`);
+			// Then we check that both can communicate together.
+			auto answer = api.postConcatBody2(Example6API.FooType(42, "fortySomething", 51.42));
+			assert(answer == expected);
+		}
 	}
 }
 

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -463,11 +463,14 @@ package struct WebParamAttribute {
 	string field;
 }
 
+package(vibe.web) enum bodyParamWholeName = "bodyParamWhole";
+
 /**
  * Declare that a parameter will be transmitted to the API through the body.
  *
  * It will be serialized as part of a JSON object.
  * The serialization format is currently not customizable.
+ * If no fieldname is given, the entire body is serialized into the object.
  *
  * Params:
  * - identifier: The name of the parameter to customize. A compiler error will be issued on mismatch.
@@ -486,6 +489,15 @@ WebParamAttribute bodyParam(string identifier, string field)
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
 	return WebParamAttribute(ParameterKind.body_, identifier, field);
+}
+
+/// ditto
+WebParamAttribute bodyParam(string identifier)
+@safe {
+	import vibe.web.internal.rest.common : ParameterKind;
+	if (!__ctfe)
+		assert(false, onlyAsUda!__FUNCTION__);
+	return WebParamAttribute(ParameterKind.body_, identifier, bodyParamWholeName);
 }
 
 /**

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -463,7 +463,6 @@ package struct WebParamAttribute {
 	string field;
 }
 
-package(vibe.web) enum bodyParamWholeName = "bodyParamWhole";
 
 /**
  * Declare that a parameter will be transmitted to the API through the body.
@@ -483,8 +482,12 @@ package(vibe.web) enum bodyParamWholeName = "bodyParamWhole";
  * // { "package": 42 }
  * ----
  */
-WebParamAttribute bodyParam(string identifier, string field)
-@safe {
+WebParamAttribute bodyParam(string identifier, string field) @safe
+in {
+	assert(field.length > 0, "fieldname can't be empty.");
+}
+body
+{
 	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
@@ -497,7 +500,7 @@ WebParamAttribute bodyParam(string identifier)
 	import vibe.web.internal.rest.common : ParameterKind;
 	if (!__ctfe)
 		assert(false, onlyAsUda!__FUNCTION__);
-	return WebParamAttribute(ParameterKind.body_, identifier, bodyParamWholeName);
+	return WebParamAttribute(ParameterKind.body_, identifier, "");
 }
 
 /**


### PR DESCRIPTION
As discussed in #1549 and  #1422:

```d
@bodyParam("obj")
string postFoo(FooType obj);
```

Moreover if
- no `@bodyParam` annotation is provided
- the method is automatically recognized as `POST`
- there's only _one_ `@bodyParam` parameter

```d
string postFoo(FooType obj);
```

then the entire Json body is serialized into this parameter. This might be a breaking change, but imho it's a sane default setting as most APIs want to serialize the entire request body and vibe.d hasn't reached stable yet.