### PR TITLE
Add web authentication example

### DIFF
--- a/examples/web-auth/dub.json
+++ b/examples/web-auth/dub.json
@@ -1,0 +1,8 @@
+{
+	"name": "web-auth-example",
+	"description": "Simple service using the web framework.",
+	"dependencies": {
+		"vibe-d:web": {"path": "../../"}
+	},
+	"versions": ["VibeDefaultMain"]
+}

--- a/examples/web-auth/public/styles/common.css
+++ b/examples/web-auth/public/styles/common.css
@@ -1,0 +1,2 @@
+body { font-family: sans-serif; }
+.error { color: red; }

--- a/examples/web-auth/source/app.d
+++ b/examples/web-auth/source/app.d
@@ -1,0 +1,170 @@
+// This module implements a simple web service with a login form and two
+// settings that can be changed by the logged in user.
+// It uses an authorization framework for fine-grained roles.
+module app;
+
+import std.exception : enforce;
+import vibe.core.log;
+import vibe.http.fileserver;
+import vibe.http.router;
+import vibe.http.server;
+import vibe.utils.validation;
+import vibe.web.auth;
+import vibe.web.web;
+
+// Aggregates information and roles about the currently logged in user
+struct AuthInfo {
+	string userName;
+    bool premium;
+    bool admin;
+
+	@safe:
+	bool isAdmin() { return this.admin; }
+	bool isPremiumUser() { return this.premium; }
+}
+
+/**
+The methods of this class will be mapped to HTTP routes and serve as request handlers.
+The @requiresAuth annotation demands that every public method is annotated with either:
+- @noAuth
+- @anyAuth
+- @auth(...)
+*/
+@requiresAuth
+class SampleService {
+
+	// The authentication handler which will be called whenever auth info is needed.
+	// Its return type can be injected into the routes of the associated service.
+	// (for obvious reasons this shouldn't be a route itself)
+	@noRoute
+	AuthInfo authenticate(scope HTTPServerRequest req, scope HTTPServerResponse res) @safe
+	{
+		if (!req.session || !req.session.isKeySet("auth"))
+			throw new HTTPStatusException(HTTPStatus.forbidden, "Not authorized to perform this action!");
+
+		return req.session.get!AuthInfo("auth");
+	}
+
+	// All public routes wrapped into one block
+	@noAuth {
+
+		// "GET /"
+		// overrides the path that gets inferred from the method name to
+		// HTTPServer{Request, Response} parameters get automatically injected
+		@path("/") void getHome(scope HTTPServerRequest req)
+		{
+			import std.typecons : Nullable;
+
+			Nullable!AuthInfo auth;
+			if (req.session && req.session.isKeySet("auth"))
+				auth = req.session.get!AuthInfo("auth");
+
+			render!("home.dt", auth);
+		}
+
+		// Method name gets mapped to "GET /login" and a single optional
+		// _error parameter is accepted (see postLogin)
+		void getLogin(string _error = null)
+		{
+			string error = _error;
+			render!("login.dt", error);
+		}
+
+		// Method name gets mapped to "POST /login" and two HTTP form parameters
+		// (taken from HTTPServerRequest.form or .query) are accepted.
+		//
+		// The @errorDisplay attribute causes any exceptions to be passed to the
+		// _error parameter of getLogin to render the error. The same happens for
+		// validation errors (ValidUsername).
+		@errorDisplay!getLogin
+		void postLogin(ValidUsername user, string password, scope HTTPServerRequest req, scope HTTPServerResponse res)
+		{
+			enforce(password == "secret", "Invalid password.");
+
+			AuthInfo s = {userName: user};
+			req.session = res.startSession;
+			req.session.set("auth", s);
+			redirect("./");
+		}
+	}
+
+	// Routes that require any kind of authentication
+	@anyAuth {
+
+		// GET /logout
+		void postLogout()
+		{
+			terminateSession();
+			redirect("./");
+		}
+
+		// GET /settings
+		// authUser is automatically injected based on the authenticate() result
+		void getSettings(AuthInfo auth, string _error = null)
+		{
+			auto error = _error;
+			render!("settings.dt", error, auth);
+		}
+
+		// POST /settings
+		// @errorDisplay will render errors using the getSettings method.
+		// authUser gets injected with the associated authenticate()
+		@errorDisplay!getSettings
+		void postSettings(bool premium, bool admin, ValidUsername user_name, AuthInfo authUser, scope HTTPServerRequest req)
+		{
+			AuthInfo s = authUser;
+			s.userName = user_name;
+			s.premium = premium;
+			s.admin = admin;
+			req.session.set("auth", s);
+			redirect("./");
+		}
+	}
+
+	/**
+		With @auth specific roles can be required. Moreover, they can be combined:
+
+		    @auth(Role.admin) - requires an admin role
+		    @auth(Role.admin | Role.premium) - requires an admin or a premium role
+		    @auth(Role.admin & Role.premium) - requires an admin and a premium role
+
+		The role is mapped to is<NameOfTheRole> of the type returned by the regarding
+		authenticate method. For example, `Role.admin` will call `AuthInfo.isAdmin`
+	*/
+
+	// GET /premium
+	@auth(Role.admin | Role.premiumUser)
+	void getPremium()
+	{
+		render!("premium.dt");
+	}
+
+	// GET /admin
+	@auth(Role.admin)
+	void getAdmin()
+	{
+		render!("admin.dt");
+	}
+}
+
+
+shared static this()
+{
+	// Create the router that will dispatch each request to the proper handler method
+	auto router = new URLRouter;
+	// Register our sample service class as a web interface. Each public method
+	// will be mapped to a route in the URLRouter
+	router.registerWebInterface(new SampleService);
+	// All requests that haven't been handled by the web interface registered above
+	// will be handled by looking for a matching file in the public/ folder.
+	router.get("*", serveStaticFiles("public/"));
+
+	// Start up the HTTP server
+	auto settings = new HTTPServerSettings;
+	settings.port = 8080;
+	settings.bindAddresses = ["::1", "127.0.0.1"];
+	settings.sessionStore = new MemorySessionStore;
+	listenHTTP(settings, router);
+
+	logInfo("Please open http://127.0.0.1:8080/ in your browser.");
+}

--- a/examples/web-auth/views/admin.dt
+++ b/examples/web-auth/views/admin.dt
@@ -1,0 +1,9 @@
+extends layout
+
+block head
+	- auto title = "Admin area";
+
+block contents
+	a(href="#{req.rootDir}") Back
+
+	p Admin Area.

--- a/examples/web-auth/views/home.dt
+++ b/examples/web-auth/views/home.dt
@@ -1,0 +1,19 @@
+extends layout
+
+block head
+	- auto title = "Home";
+
+block contents
+
+	- if (!auth.isNull)
+		p Hello, #{auth.userName}! Welcome to your personal web service.
+
+		p You can <a href="settings">edit settings</a>.
+
+		p Currently your <a href="premium">premium membership</a> is #{auth.isPremiumUser ? "on" : "off"}.
+
+		- if (auth.isAdmin)
+			p View the <a href="admin"> admin panel </a>
+	- else
+		p This is an example web service.
+		p Please <a href="login">log in</a>.

--- a/examples/web-auth/views/layout.dt
+++ b/examples/web-auth/views/layout.dt
@@ -1,0 +1,13 @@
+doctype html
+html
+	head
+		block head
+		link(rel="stylesheet", href="#{req.rootDir}styles/common.css")
+		title #{title} - Sample service
+	body
+		- if (req.session)
+			form(method="POST", action="#{req.rootDir}logout")
+				button(type="submit") Log out
+
+		h1= title
+		block contents

--- a/examples/web-auth/views/login.dt
+++ b/examples/web-auth/views/login.dt
@@ -1,0 +1,19 @@
+extends layout
+
+block head
+	- auto title = "Log in";
+
+block contents
+	form(method="POST", action="login")
+		div
+			label(for="user") User name:
+			input#user(name="user", type="text")
+		div
+			label(for="password") Password (use "secret"):
+			input#password(name="password", type="password")
+
+		- if (error.length)
+			p.error= error
+
+		div
+			button(type="sumbit") Apply

--- a/examples/web-auth/views/premium.dt
+++ b/examples/web-auth/views/premium.dt
@@ -1,0 +1,9 @@
+extends layout
+
+block head
+	- auto title = "Premium area";
+
+block contents
+	a(href="#{req.rootDir}") Back
+
+	p Premium Area.

--- a/examples/web-auth/views/settings.dt
+++ b/examples/web-auth/views/settings.dt
@@ -1,0 +1,33 @@
+extends layout
+
+block head
+	- auto title = "Settings";
+
+block contents
+	a(href="#{req.rootDir}") Back
+
+	form(method="POST", action="settings")
+		div
+			- if (auth.isPremiumUser)
+				input#premium(name="premium", type="checkbox", checked)
+			- else
+				input#premium(name="premium", type="checkbox")
+			label(for="premium") Premium membership
+
+		div
+			- if (auth.isAdmin)
+				input#admin(name="admin", type="checkbox", checked)
+			- else
+				input#admin(name="admin", type="checkbox")
+			label(for="admin") Admin user
+
+		div
+			label(for="username") User name
+			br
+			input#username(name="user_name", type="text", value=auth.userName)
+
+		- if (error.length)
+			p.error= error
+
+		div
+			button(type="sumbit") OK

--- a/web/vibe/web/web.d
+++ b/web/vibe/web/web.d
@@ -697,8 +697,9 @@ private void handleRequest(string M, alias overload, C, ERROR...)(HTTPServerRequ
 	else enum nested_style = NestedNameStyle.underscore;
 
 	s_requestContext = createRequestContext!overload(req, res);
+	enum hasAuth = isAuthenticated!(C, overload);
 
-	static if (isAuthenticated!(C, overload)) {
+	static if (hasAuth) {
 		auto auth_info = handleAuthentication!overload(instance, req, res);
 		if (res.headerWritten) return;
 	}
@@ -710,7 +711,7 @@ private void handleRequest(string M, alias overload, C, ERROR...)(HTTPServerRequ
 		ParamError err;
 		err.field = param_names[i];
 		try {
-			static if (is(PT == AuthInfoType)) {
+			static if (hasAuth && is(PT == AuthInfoType)) {
 				params[i] = auth_info;
 			} else static if (IsAttributedParameter!(overload, param_names[i])) {
 				params[i].setVoid(computeAttributedParameterCtx!(overload, param_names[i])(instance, req, res));
@@ -804,7 +805,7 @@ private void handleRequest(string M, alias overload, C, ERROR...)(HTTPServerRequ
 		}
 	}
 
-	static if (isAuthenticated!(C, overload))
+	static if (hasAuth)
 		handleAuthorization!(C, overload, params)(auth_info);
 
 	// execute the method and write the result


### PR DESCRIPTION
Vibe.d's authorization framework is amazing, but it's a quite hard to find examples for it (except for [its documentation](http://vibed.org/api/vibe.web.auth/)).

This is based on the original web service example, but instead of `@before` it uses the `vibe.web.auth` framework for access and role management. I added two dummy pages, s.t. the access roles can be checked.

I deliberately avoided using `SessionVar` as this would somewhat make the injection of the current `authUser` redundant in this example.