### PR TITLE
[RFC] vibe.web.web: Map _underscored variables without UDAs or injections to req.path

### DIFF
--- a/tests/vibe.web.web/dub.json
+++ b/tests/vibe.web.web/dub.json
@@ -3,5 +3,5 @@
 	"dependencies": {
 		"vibe-d:web": { "path": "../../" }
 	},
-	"versions": ["VibeDefaultMain"]
+	"versions": ["VibeCustomMain"]
 }

--- a/tests/vibe.web.web/source/app.d
+++ b/tests/vibe.web.web/source/app.d
@@ -5,42 +5,53 @@ import vibe.core.log;
 import vibe.http.client;
 import vibe.http.router;
 import vibe.http.server;
+import vibe.stream.operations : readAllUTF8;
 import vibe.web.web;
 import std.format : format;
 
 // TODO: test the various parameter and return type combinations, as well as all attributes
 
-shared static this()
+int main()
 {
-	auto settings = new HTTPServerSettings;
-	settings.bindAddresses = ["127.0.0.1"];
-	settings.port = 9132;
-
-	auto router = new URLRouter;
-	router.registerWebInterface(new Service);
-
-	listenHTTP(settings, router);
-
 	runTask({
 		scope (exit) exitEventLoop();
 
-		void test(string url, HTTPStatus expected) {
+		auto settings = new HTTPServerSettings;
+		settings.bindAddresses = ["127.0.0.1"];
+		settings.port = 9132;
+
+		auto router = new URLRouter;
+		router.registerWebInterface(new Service);
+
+		listenHTTP(settings, router);
+
+		void test(string url, HTTPStatus expected, scope void delegate(HTTPClientResponse res) responseHandler = null) {
 			requestHTTP("http://127.0.0.1:9132"~url,
 				(scope req) {
 				},
 				(scope res) {
-					res.dropBody();
 					assert(res.statusCode == expected, format("Unexpected status code for %s: %s", url, res.statusCode));
+					if (responseHandler)
+						responseHandler(res);
+					res.dropBody();
 				}
 			);
 		}
 		test("/foo", HTTPStatus.notFound);
 		test("/bar", HTTPStatus.ok);
+		test("/user/5", HTTPStatus.ok, (scope res) {
+			assert(res.bodyReader.readAllUTF8 == "User: 5");
+		});
 		logInfo("All web tests succeeded.");
 	});
+	return runEventLoop;
 }
 
 class Service {
 	@noRoute void getFoo(HTTPServerResponse res) { res.writeBody("oops"); }
 	void getBar(HTTPServerResponse res) { res.writeBody("ok"); }
+
+	void getUser(string _id, HTTPServerResponse res) {
+		res.writeBody("User: " ~ _id);
+	}
 }

--- a/web/vibe/web/web.d
+++ b/web/vibe/web/web.d
@@ -54,7 +54,7 @@ import std.encoding : sanitize;
 	$(TABLE
 		$(TR $(TH HTTP method) $(TH Recognized prefixes))
 		$(TR $(TD GET)	  $(TD get, query))
-		$(TR $(TD PUT)    $(TD set, put))
+		$(TR $(TD PUT)	  $(TD set, put))
 		$(TR $(TD POST)   $(TD add, create, post))
 		$(TR $(TD DELETE) $(TD remove, erase, delete))
 		$(TR $(TD PATCH)  $(TD update, patch))
@@ -158,6 +158,8 @@ URLRouter registerWebInterface(C : Object, MethodStyle method_style = MethodStyl
 		url_prefix = concatURL(url_prefix, cls_path.value, true);
 	}
 
+	alias AuthInfoType = AuthInfo!C;
+
 	foreach (M; __traits(allMembers, C)) {
 		/*static if (isInstanceOf!(SessionVar, __traits(getMember, instance, M))) {
 			__traits(getMember, instance, M).m_getContext = toDelegate({ return s_requestContext; });
@@ -181,7 +183,47 @@ URLRouter registerWebInterface(C : Object, MethodStyle method_style = MethodStyl
 					subsettings.urlPrefix = concatURL(url_prefix, url, true);
 					registerWebInterface!RT(router, __traits(getMember, instance, M)(), subsettings);
 				} else {
-					auto fullurl = concatURL(url_prefix, url);
+					import std.meta : AliasSeq, ApplyLeft, Filter, templateAnd, templateNot;
+
+					// adds underscored params to the route param parser
+					static if (!minfo.hadPathUDA) {
+						import vibe.internal.meta.funcattr : IsAttributedParameter;
+						import std.range.primitives : empty;
+
+						// exclude all other possible injection paths
+						enum hasOtherInjectionPath(PT) = is(PT == InputStream) ||
+							is(PT == HTTPServerRequest) || is(PT == HTTPRequest) ||
+							is(PT == HTTPServerResponse) || is(PT == HTTPResponse) ||
+							is(PT == WebSocket) ||
+							is(PT == bool) ||
+							is(PT == AuthInfoType);
+						alias hasNoAttributes = templateNot!(ApplyLeft!(IsAttributedParameter, overload));
+						alias paramTypes = Parameters!overload;
+						enum param_names = {
+							string[] params;
+							foreach (i, paramName; ParameterIdentifierTuple!overload)
+							{
+								if (paramName[0] == '_' && hasNoAttributes!paramName &&
+										!hasOtherInjectionPath!(paramTypes[i]) &&
+									paramName != "_error")
+									params ~= paramName;
+							}
+							return params;
+						}();
+						static if (!param_names.empty) {
+							string endurl;
+							foreach (name; param_names) {
+								endurl ~= "/:" ~ name[1 .. $];
+							}
+							auto fullurl = concatURL(url_prefix, url.concatURL(endurl));
+						} else {
+							auto fullurl = concatURL(url_prefix, url);
+						}
+					} else {
+						auto fullurl = concatURL(url_prefix, url);
+					}
+					import vibe.core.log;
+					logDebug("[Web] registering: %s", fullurl);
 					router.match(minfo.method, fullurl, (HTTPServerRequest req, HTTPServerResponse res) @trusted {
 						handleRequest!(M, overload)(req, res, instance, settings);
 					});
@@ -283,7 +325,7 @@ unittest {
 	$(UL
 		$(LI The `req` variable that holds the current request object)
 		$(LI If the `@translationContext` attribute us used, enables the
-		     built-in i18n support of Diet templates)
+			 built-in i18n support of Diet templates)
 	)
 */
 template render(string diet_file, ALIASES...) {
@@ -367,7 +409,7 @@ void redirect(string url)
 		fullurl.localURI = url;
 	} else if (url.canFind(":")) { // TODO: better URL recognition
 		fullurl = URL(url);
-	} else  if (ctx.req.fullURL.path.endsWithSlash) {
+	} else	if (ctx.req.fullURL.path.endsWithSlash) {
 		fullurl = ctx.req.fullURL;
 		fullurl.localURI = fullurl.path.toString() ~ url;
 	} else {


### PR DESCRIPTION
Here's another idea if mine.

In `vibe.web.web`, there's already support for injection of route parameters based on variables starting with `_`. This RFC takes this behavior and makes it auto-magically the default when a variable starts with an underscore and no UDA attached to it or no other injection method attached.
Of course the user can still manually define paths.

An example for this convenient style:

```
// /:id/
void getBook(string _id) {
   // get the book & return it
}
// /:parent/:id
void getBooks(string _parent, int _id) {
   // get the book & return it
}
```