### PR TITLE
Simple fix to REST bool query parameters

### DIFF
--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -1521,7 +1521,7 @@ private {
 		import vibe.web.common : HTTPStatusException, HTTPStatus;
 		try {
 			static if (isInstanceOf!(Nullable, T)) return T(fromRestString!(typeof(T.init.get()))(value));
-			else static if (is(T == bool)) return value == "true";
+			else static if (is(T == bool)) return value == "1" || value.to!T;
 			else static if (is(T : int)) return to!T(value);
 			else static if (is(T : double)) return to!T(value); // FIXME: formattedWrite(dst, "%.16g", json.get!double);
 			else static if (is(string : T)) return value;


### PR DESCRIPTION
Just a simple fix to REST handler when bool query parameter is used. Not all clients generates expected "true" so it should be case insensitive.
Also sending 0 or 1 is pretty common.