### PR TITLE
Fix & test Meson builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: d
 sudo: false
+dist: trusty
 
 services:
   - mongodb
   - redis-server
+
+addons:
+  apt:
+    packages:
+    - libevent-dev
+    - libssl-dev
+    - pkg-config
+    - zlib1g-dev
 
 d:
   # order: latest DMD, oldest DMD, LDC/GDC, remaining DMD versions
@@ -13,7 +22,8 @@ d:
   - dmd-2.073.2
   - dmd-2.068.2
   - ldc-1.0.0
-  - ldc-1.1.0
+  - ldc-1.1.1
+  - ldc-1.2.0-beta1
   - dmd-2.072.2
   - dmd-2.071.2
   - dmd-2.070.2
@@ -29,9 +39,22 @@ matrix:
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
   allow_failures:
     - d: dmd-beta
-    - d: ldc-1.1.0
+    - d: ldc-1.2.0-beta1
+      env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
+    - d: ldc-1.1.1
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
     - d: dmd-2.068.2
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
+
+before_install:
+  - pip3 install meson
+
+install:
+  - mkdir .ntmp
+  - curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o .ntmp/ninja-linux.zip
+  - unzip .ntmp/ninja-linux.zip -d .ntmp
+
+before_script:
+  - export PATH=$PATH:$PWD/.ntmp
 
 script: ./travis-ci.sh

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ source_root = meson.source_root()
 build_root = meson.build_root()
 
 project_version      = '0.7.30'
-project_version_name = '0.7.30~beta.1'
+project_version_name = '0.7.30'
 project_soversion    = '0'
 
 pkgc = import('pkgconfig')
@@ -177,7 +177,18 @@ crypto_dep = dependency('libcrypto')
 ssl_dep = dependency('libssl')
 libevent_dep = dependency('libevent')
 
+# stupid hack to generate a relative path to the build directory, since newer
+# Meson does not allow absolute paths to the build directory in include_directories()
+# anymore.
+# FIXME: Needs to be reported upstream as an issue.
+
 external_subprojects_dir = build_root + '/subprojects'
+relpath_hack = run_command('python3', '-c', 'import os.path; print(os.path.relpath(\'' + build_root + '\', \'' + source_root + '\'))')
+if relpath_hack.returncode() == 0
+    external_subprojects_dir = relpath_hack.stdout().strip() + '/subprojects'
+else
+    error('Unable to determine relative path to build directory: ' + relpath_hack.stderr().strip())
+endif
 
 # Try to find system OpenSSL bindings, if not found, download
 # a Git copy.
@@ -194,7 +205,7 @@ else
         endif
     endif
 
-    message('Using non-system of OpenSSL D bindings.')
+    message('Using non-system OpenSSL D bindings.')
 endif
 openssl_inc = include_directories(openssl_src_dir)
 
@@ -213,7 +224,7 @@ else
         endif
     endif
 
-    message('Using non-system of LibEvent D bindings.')
+    message('Using non-system LibEvent D bindings.')
 endif
 libevent_inc = include_directories(libevent_src_dir)
 

--- a/meson.build
+++ b/meson.build
@@ -43,13 +43,11 @@ vibe_core_src = [
     'source/vibe/core/core.d',
     'source/vibe/core/driver.d'
 ]
-install_headers(vibe_core_src, subdir: 'd/vibe/core')
 
 vibe_crypto_src = [
     'source/vibe/crypto/passwordhash.d',
     'source/vibe/crypto/cryptorand.d'
 ]
-install_headers(vibe_crypto_src, subdir: 'd/vibe/crypto')
 
 vibe_inet_src = [
     'source/vibe/inet/path.d',
@@ -59,7 +57,6 @@ vibe_inet_src = [
     'source/vibe/inet/urltransfer.d',
     'source/vibe/inet/message.d'
 ]
-install_headers(vibe_inet_src, subdir: 'd/vibe/inet')
 
 vibe_stream_src = [
     'source/vibe/stream/botan.d',
@@ -75,14 +72,12 @@ vibe_stream_src = [
     'source/vibe/stream/memory.d',
     'source/vibe/stream/wrapper.d'
 ]
-install_headers(vibe_stream_src, subdir: 'd/vibe/stream')
 
 vibe_textfilter_src = [
     'source/vibe/textfilter/markdown.d',
     'source/vibe/textfilter/urlencode.d',
     'source/vibe/textfilter/html.d'
 ]
-install_headers(vibe_textfilter_src, subdir: 'd/vibe/textfilter')
 
 vibe_utils_src = [
     'source/vibe/utils/validation.d',
@@ -92,7 +87,6 @@ vibe_utils_src = [
     'source/vibe/utils/memory.d',
     'source/vibe/utils/string.d'
 ]
-install_headers(vibe_utils_src, subdir: 'd/vibe/utils')
 
 vibe_internal_src = [
     'source/vibe/internal/win32.d',
@@ -104,14 +98,12 @@ vibe_internal_src = [
     'source/vibe/internal/meta/uda.d',
     'source/vibe/internal/rangeutil.d'
 ]
-install_headers(vibe_internal_src, subdir: 'd/vibe/internal')
 
 vibe_data_src = [
     'source/vibe/data/bson.d',
     'source/vibe/data/serialization.d',
     'source/vibe/data/json.d'
 ]
-install_headers(vibe_data_src, subdir: 'd/vibe/data')
 
 vibe_http_src = [
     'source/vibe/http/session.d',
@@ -129,19 +121,16 @@ vibe_http_src = [
     'source/vibe/http/fileserver.d',
     'source/vibe/http/status.d'
 ]
-install_headers(vibe_http_src, subdir: 'd/vibe/http')
 
 vibe_mail_src = [
     'source/vibe/mail/smtp.d',
 ]
-install_headers(vibe_mail_src, subdir: 'd/vibe/mail')
 
 vibe_diet_src = [
     'source/vibe/templ/parsertools.d',
     'source/vibe/templ/utils.d',
     'source/vibe/templ/diet.d'
 ]
-install_headers(vibe_diet_src, subdir: 'd/vibe/templ')
 
 vibe_db_mongo_src = [
     'source/vibe/db/mongo/connection.d',
@@ -153,7 +142,6 @@ vibe_db_mongo_src = [
     'source/vibe/db/mongo/settings.d',
     'source/vibe/db/mongo/flags.d'
 ]
-install_headers(vibe_db_mongo_src, subdir: 'd/vibe/db/mongo')
 
 vibe_db_redis_src = [
     'source/vibe/db/redis/idioms.d',
@@ -161,7 +149,6 @@ vibe_db_redis_src = [
     'source/vibe/db/redis/sessionstore.d',
     'source/vibe/db/redis/redis.d'
 ]
-install_headers(vibe_db_redis_src, subdir: 'd/vibe/db/redis')
 
 vibe_web_src = [
     'source/vibe/web/validation.d',
@@ -173,7 +160,14 @@ vibe_web_src = [
     'source/vibe/web/rest.d',
     'source/vibe/web/i18n.d'
 ]
-install_headers(vibe_web_src, subdir: 'd/vibe/web')
+
+#
+# Includes
+#
+# It's easier to just install the whole source-tree then use
+# install_headers and forget to include all subdirectories
+# along the way.
+install_subdir('source/vibe/', install_dir: 'include/d/')
 
 #
 # Dependencies

--- a/meson.build
+++ b/meson.build
@@ -177,18 +177,9 @@ crypto_dep = dependency('libcrypto')
 ssl_dep = dependency('libssl')
 libevent_dep = dependency('libevent')
 
-# stupid hack to generate a relative path to the build directory, since newer
-# Meson does not allow absolute paths to the build directory in include_directories()
-# anymore.
-# FIXME: Needs to be reported upstream as an issue.
-
-external_subprojects_dir = build_root + '/subprojects'
-relpath_hack = run_command('python3', '-c', 'import os.path; print(os.path.relpath(\'' + build_root + '\', \'' + source_root + '\'))')
-if relpath_hack.returncode() == 0
-    external_subprojects_dir = relpath_hack.stdout().strip() + '/subprojects'
-else
-    error('Unable to determine relative path to build directory: ' + relpath_hack.stderr().strip())
-endif
+# directory where the external dependencies are included from.
+# Meson will search for this dir in both build_root and source_root
+external_subprojects_dir = 'subprojects'
 
 # Try to find system OpenSSL bindings, if not found, download
 # a Git copy.


### PR DESCRIPTION
This PR fixes the meson builds and adds a few quirk fixes as well. It also allows testing Meson in Travis (LDC only for now).

The following issues exist and have been partially resolved:
 * Meson doesn't allow absolute paths in `include_directories` anymore if they point to the source dir. This breaks a previous hack added to download 3rd-party dependencies. I added another hack to work around this for now, but I will raise this at Meson upstream now to get this resolved somehow.
 * Building Vibe with DMD+Meson apparently doesn't work since DMD doesn't recognize the versioned library parameter. I am not sure of this is a Meson or DMD issue, at time I think it's Meson not translating a flag to the DMD-specific syntax. Will need some investigation.

The other change is installing the whole source directory to `include/d` now, since previously some paths weren't correctly created, breaking software depending on Vibe.
This patch is also already applied in Debian.

Due to the issues with DMD, the Travis test builds for Meson are only enabled for LDC for now.
Since libasync doesn't have a Meson build file, Meson build-config is also libevent-only, but that has been this was before.

Please note that this PR targets the 0.7.x branch, not master!

Thanks for developing Vibe.d!