### PR TITLE
Use "Connection: close" instead of chunked encoding on HTTP/1.0

### DIFF
--- a/source/vibe/http/server.d
+++ b/source/vibe/http/server.d
@@ -1130,6 +1130,11 @@ final class HTTPServerResponse : HTTPResponse {
 			writeHeader();
 			m_countingWriter.writeLimit = (*pcl).to!ulong;
 			m_bodyWriter = m_countingWriter;
+		} else if (httpVersion <= HTTPVersion.HTTP_1_0) {
+			if ("Connection" in headers)
+				headers.remove("Connection"); // default to "close"
+			writeHeader();
+			m_bodyWriter = m_conn;
 		} else {
 			headers["Transfer-Encoding"] = "chunked";
 			writeHeader();

--- a/tests/vibe.http.server.1721/dub.sdl
+++ b/tests/vibe.http.server.1721/dub.sdl
@@ -1,0 +1,4 @@
+name "tests"
+description "Wrong host header tests"
+dependency "vibe-d:http" path="../../"
+versions "VibeDefaultMain"

--- a/tests/vibe.http.server.1721/source/app.d
+++ b/tests/vibe.http.server.1721/source/app.d
@@ -1,0 +1,44 @@
+import vibe.core.core;
+import vibe.core.net;
+import vibe.http.server;
+import vibe.stream.operations;
+import std.algorithm.searching : startsWith;
+import std.string : toLower;
+import core.time : seconds;
+
+
+shared static this()
+{
+	auto s1 = new HTTPServerSettings;
+	s1.options &= ~HTTPServerOption.errorStackTraces;
+	s1.bindAddresses = ["::1"];
+	s1.port = 11721;
+	listenHTTP(s1, &handler);
+
+	runTask({
+		scope (exit) exitEventLoop();
+
+		try {
+			auto conn = connectTCP("::1", 11721);
+			conn.write("GET / HTTP/1.0\r\n\r\n");
+			string res = cast(string)conn.readLine();
+			assert(res == "HTTP/1.0 200 OK", res);
+			while (true) {
+				auto ln = conn.readLine();
+				if (!ln.length) break;
+				assert(!(cast(const(char)[])ln).toLower().startsWith("transfer-encoding:"), "Server sent transfer encoding on HTTP/1.0 connection.");
+			}
+			assert(cast(string)conn.readLine() == "Hello, World!");
+			assert(!conn.waitForData(1.seconds), "Connection not closed by server after response was written.");
+			assert(conn.empty);
+		} catch (Exception e) {
+			assert(false, e.msg);
+		}
+	});
+}
+
+void handler(scope HTTPServerRequest req, scope HTTPServerResponse res)
+{
+	res.bodyWriter.write("Hello, ");
+	res.bodyWriter.write("World!\r\n");
+}


### PR DESCRIPTION
For variable body lengths, the server erroneously used chunked transfer encoding on HTTP/1.0 connections. Since there are still proxy servers that don't support HTTP/1.1, this can still be a practical issue. This instead switched to "Connection: close" without a "Content-Length" header.

Fixes #1721.