### PR TITLE
Fix SDLangParseException in mac

### DIFF
--- a/stream/dub.sdl
+++ b/stream/dub.sdl
@@ -26,6 +26,7 @@ configuration "windows-optlink" {
 }
 
 configuration "generic" {
-	libs "z" platform="posix-ldc" // LDC 1.0.0 doesn't include libz in libphobos
+	// LDC 1.0.0 doesn't include libz in libphobos
+	libs "z" platform="posix-ldc"
 	libs "z" platform="gdc"
 }


### PR DESCRIPTION
Starting up new project from dub, mac OS X El Capitan V10.11.6 produces the following error

```
Failed to load package in /Users/tpuric/.dub/packages/vibe-d-0.8.0-beta.5/: /Users/tpuric/.dub/packages/vibe-d-0.8.0-beta.5/stream/dub.sdl(30:10): Error: Expected '=' after attribute name, not Value
Full error: dub.internal.sdlang.exception.SDLangParseException@source/dub/internal/sdlang/exception.d(16): /Users/tpuric/.dub/packages/vibe-d-0.8.0-beta.5/stream/dub.sdl(30:10): Error: Expected '=' after attribute name, not Value
----------------
5   dub                                 0x000000010de96076 void dub.internal.sdlang.parser.PullParser.error(immutable(char)[]) + 94
6   dub                                 0x000000010de96bf2 void dub.internal.sdlang.parser.PullParser.parseAttribute() + 362
7   dub                                 0x000000010de96a82 void dub.internal.sdlang.parser.PullParser.parseAttributes() + 114
8   dub                                 0x000000010de96574 void dub.internal.sdlang.parser.PullParser.parseTag() + 548
9   dub                                 0x000000010de962f7 void dub.internal.sdlang.parser.PullParser.parseTags() + 127
10  dub                                 0x000000010de96e5f void dub.internal.sdlang.parser.PullParser.parseOptChild() + 311
11  dub                                 0x000000010de9657d void dub.internal.sdlang.parser.PullParser.parseTag() + 557
12  dub                                 0x000000010de962f7 void dub.internal.sdlang.parser.PullParser.parseTags() + 127
13  dub                                 0x000000010de961dc void dub.internal.sdlang.parser.PullParser.parseRoot() + 140
14  dub                                 0x000000010de96147 void dub.internal.sdlang.parser.PullParser.visit(dub.internal.libInputVisitor.InputVisitor!(dub.internal.sdlang.parser.PullParser, std.variant.VariantN!(104uL, dub.internal.sdlang.parser.FileStartEvent, dub.internal.sdlang.parser.FileEndEvent, dub.internal.sdlang.parser.TagStartEvent, dub.internal.sdlang.parser.TagEndEvent, dub.internal.sdlang.parser.ValueEvent, dub.internal.sdlang.parser.AttributeEvent).VariantN).InputVisitor) + 87
15  dub                                 0x000000010de861f7 void dub.internal.libInputVisitor.InputVisitor!(dub.internal.sdlang.parser.PullParser, std.variant.VariantN!(104uL, dub.internal.sdlang.parser.FileStartEvent, dub.internal.sdlang.parser.FileEndEvent, dub.internal.sdlang.parser.TagStartEvent, dub.internal.sdlang.parser.TagEndEvent, dub.internal.sdlang.parser.ValueEvent, dub.internal.sdlang.parser.AttributeEvent).VariantN).InputVisitor.run() + 23
16  dub                                 0x000000010df98ba4 void core.thread.Fiber.run() + 44
17  dub                                 0x000000010df98886 fiber_entryPoint + 98
18  ???                                 0x0000000000000000 0x0 + 0
```