### PR TITLE
Improved usablity of DictionaryList with dynamic types

### DIFF
--- a/utils/vibe/utils/dictionarylist.d
+++ b/utils/vibe/utils/dictionarylist.d
@@ -140,11 +140,20 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 		return def_val;
 	}
 
+	// DMD bug: cannot set T.init as default value for def_val parameter,
+	// because compilation fails with message:
+	//      Error: undefined identifier 'T'
 	/// ditto
-	inout(T) get(T)(string key, lazy inout(T) def_val = T.init)
+	inout(T) get(T)(string key, lazy inout(T) def_val)
 	inout if (typedGet!T) {
 		if (auto pv = key in this) return (*pv).get!T;
 		return def_val;
+	}
+
+	/// ditto
+	inout(T) get(T)(string key) // Work around DMD bug
+	inout if (typedGet!T) {
+		return get!T(key, T.init);
 	}
 
 	/** Returns all values matching the given key.
@@ -341,4 +350,5 @@ unittest {
 
 	assert(c.get("a").type == typeid(bool));
 	assert(c.get!string("b") == "Hello");
+	assert(c.get!int("c") == int.init);
 }

--- a/utils/vibe/utils/dictionarylist.d
+++ b/utils/vibe/utils/dictionarylist.d
@@ -130,6 +130,13 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 		else m_extendedFields ~= Field(keysum, key, value);
 	}
 
+	void addField(T)(string key, T value)
+	if (canAssign!T)
+	{
+		ValueType convertedValue = value;
+		addField(key, convertedValue);
+	}
+
 	/** Returns the first field that matches the given key.
 
 		If no field is found, def_val is returned.
@@ -347,8 +354,10 @@ unittest {
 	DictionaryList!(Variant) c;
 	c["a"] = true;
 	c["b"] = "Hello";
-
 	assert(c.get("a").type == typeid(bool));
 	assert(c.get!string("b") == "Hello");
 	assert(c.get!int("c") == int.init);
+	c.addField("d", 9);
+	c.addField("d", "bar");
+	assert(c.getAll("d") == [ cast(Variant) 9, cast(Variant) "bar" ]);
 }


### PR DESCRIPTION
The recently added `HTTPServerRequest.context` is a `DictionaryList!Variant`. That turns out quite cumbersome to work with. This pull request adds templated overloads for `DictionaryList`'s methods `get`, `opIndexAssign` and `addField` to get things to work intuitively.