### PR TITLE
Allow building with Meson and DMD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
 
 before_install:
-  - pip3 install meson
+  - pip3 install meson>=0.40
 
 install:
   - mkdir .ntmp

--- a/meson.build
+++ b/meson.build
@@ -3,8 +3,8 @@ project('Vibe.d', 'd')
 source_root = meson.source_root()
 build_root = meson.build_root()
 
-project_version      = '0.7.31'
-project_version_name = '0.7.31'
+project_version      = '0.7.32'
+project_version_name = '0.7.32'
 project_soversion    = '0'
 
 pkgc = import('pkgconfig')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('Vibe.d', 'd')
+project('Vibe.d', 'd', meson_version: '>=0.40.0')
 
 source_root = meson.source_root()
 build_root = meson.build_root()


### PR DESCRIPTION
Older Meson versions had a bug which prevented library builds when DMD was used, which is why DMD+Meson builds were excluded in Vibe.d so far.
I resolved the issue in Meson, so we can now test with DMD as well, yay!

(I also updated the library versions for the current in development version)