### PR TITLE
Let byKeyValue return named tuples

### DIFF
--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -687,13 +687,15 @@ struct Bson {
 	/// Iterates over all values of an object or array.
 	auto byValue() const { checkType(Type.array, Type.object); return byKeyValueImpl().map!(t => t[1]); }
 	/// Iterates over all index/value pairs of an array.
-	auto byIndexValue() const { checkType(Type.array); return byKeyValueImpl().map!(t => tuple(t[0].to!size_t, t[1])); }
+	auto byIndexValue() const { checkType(Type.array); return byKeyValueImpl().map!(t => Tuple!(size_t, "key", Bson, "value")(t[0].to!size_t, t[1])); }
 	/// Iterates over all key/value pairs of an object.
 	auto byKeyValue() const { checkType(Type.object); return byKeyValueImpl(); }
 
 	private auto byKeyValueImpl()
 	const {
 		checkType(Type.object, Type.array);
+
+		alias T = Tuple!(string, "key", Bson, "value");
 		
 		static struct Rng {
 			private {
@@ -703,7 +705,7 @@ struct Bson {
 			}
 
 			@property bool empty() const { return data.length == 0; }
-			@property Tuple!(string, Bson) front() { return tuple(key, value); }
+			@property T front() { return T(key, value); }
 			@property Rng save() const { return this; }
 
 			void popFront()

--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -78,7 +78,7 @@ import std.format;
 import std.string;
 import std.range;
 import std.traits;
-import std.typecons : tuple;
+import std.typecons : Tuple;
 import std.bigint;
 
 /******************************************************************************/
@@ -463,10 +463,12 @@ struct Json {
 		return 0;
 	}
 
+	private alias KeyValue = Tuple!(string, "key", Json, "value");
+
 	/// Iterates over all key/value pairs of an object.
-	@property auto byKeyValue() @trusted { checkType!(Json[string])("byKeyValue"); return m_object.byKeyValue.map!(kv => tuple(kv.key, kv.value)).trustedRange; }
+	@property auto byKeyValue() @trusted { checkType!(Json[string])("byKeyValue"); return m_object.byKeyValue.map!(kv => KeyValue(kv.key, kv.value)).trustedRange; }
 	/// ditto
-	@property auto byKeyValue() const @trusted { checkType!(Json[string])("byKeyValue"); return m_object.byKeyValue.map!(kv => tuple(kv.key, kv.value)).trustedRange; }
+	@property auto byKeyValue() const @trusted { checkType!(Json[string])("byKeyValue"); return m_object.byKeyValue.map!(kv => const(KeyValue)(kv.key, kv.value)).trustedRange; }
 	/// Iterates over all index/value pairs of an array.
 	@property auto byIndexValue() { checkType!(Json[])("byIndexValue"); return zip(iota(0, m_array.length), m_array); }
 	/// ditto

--- a/utils/vibe/utils/dictionarylist.d
+++ b/utils/vibe/utils/dictionarylist.d
@@ -31,15 +31,17 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 	import std.typecons : Tuple;
 
 	private {
+		alias KeyValue = Tuple!(string, "key", ValueType, "value");
+		
 		static struct Field {
 			static if (USE_HASHSUM) uint keyCheckSum;
 			else {
 				enum keyCheckSum = 0;
 				this(uint, string key, VALUE value) { this.key = key; this.value = value; }
 			}
-			Tuple!(string, VALUE) tuple;
-			@property ref inout(string) key() inout { return tuple[0]; }
-			@property ref inout(VALUE) value() inout { return tuple[1]; }
+			KeyValue tuple;
+			@property ref inout(string) key() inout { return tuple.key; }
+			@property ref inout(VALUE) value() inout { return tuple.value; }
 		}
 		Field[NUM_STATIC_FIELDS] m_fields;
 		size_t m_fieldCount = 0;
@@ -250,7 +252,7 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 			size_t idx;
 
 			@property bool empty() const { return idx >= list.length; }
-			@property ref Tuple!(string, ValueType) front() {
+			@property ref KeyValue front() {
 				if (idx < list.m_fieldCount)
 					return list.m_fields[idx].tuple;
 				return list.m_extendedFields[idx - list.m_fieldCount].tuple;
@@ -267,7 +269,7 @@ struct DictionaryList(VALUE, bool case_sensitive = true, size_t NUM_STATIC_FIELD
 			size_t idx;
 
 			@property bool empty() const { return idx >= list.length; }
-			@property ref const(Tuple!(string, ValueType)) front() {
+			@property ref const(KeyValue) front() {
 				if (idx < list.m_fieldCount)
 					return list.m_fields[idx].tuple;
 				return list.m_extendedFields[idx - list.m_fieldCount].tuple;


### PR DESCRIPTION
Bson, Json and DictionaryList now return a named tuple with .key and .value members instead of plain tuples. Fixes #1763.