### PR TITLE
Mark BotanTLSContext constructor as trusted

### DIFF
--- a/stream/vibe/stream/botan.d
+++ b/stream/vibe/stream/botan.d
@@ -295,7 +295,7 @@ class BotanTLSContext : TLSContext {
 		 TLSPolicy policy = null, 
 		 TLSSessionManager session_manager = null,
 		 bool is_datagram = false)
-	{
+	@trusted {
 		if (!credentials)
 			credentials = new CustomTLSCredentials();
 		m_kind = kind;


### PR DESCRIPTION
Fixes
```
../vibe.d/stream/vibe/stream/tls.d(102,11): Error: @safe function 'vibe.stream.tls.createTLSContext.createBotanContext' cannot call @system constructor 'vibe.stream.botan.BotanTLSContext.this'
```