### PR TITLE
Have versions block prevent importing openssl when using botan

### DIFF
--- a/stream/vibe/stream/openssl.d
+++ b/stream/vibe/stream/openssl.d
@@ -6,7 +6,11 @@
 	Authors: Sönke Ludwig
 */
 module vibe.stream.openssl;
-version(Have_openssl):
+version(Have_botan)
+{
+} else version(VibeNoSSL)
+{
+} else version(Have_openssl):
 import vibe.core.log;
 import vibe.core.net;
 import vibe.core.stream;

--- a/stream/vibe/stream/tls.d
+++ b/stream/vibe/stream/tls.d
@@ -30,8 +30,8 @@ import core.sync.mutex;
 import core.thread;
 
 version (VibeNoSSL) {}
-else version(Have_openssl) version = OpenSSL;
 else version(Have_botan) version = Botan;
+else version(Have_openssl) version = OpenSSL;
 
 
 /// A simple TLS client


### PR DESCRIPTION
I had to move around the version block in openssl.d and add a few version blocks in tls.d to prevent pulling in openssl when using botan.

It all started on ArchLinux yesterday where I found out the deimos bindings for openssl are incompatible with the latest openssl version on arch.

Then I started trying to compile vibe.d without openssl. This turned out to be quite hard since no matter what I did, dub kept settings the 'Have_openssl' version, which in turn made vibe.d import the deimos bindings. (Is this correct behaviour in dub? settings the version for optional dependencies? I think it should not since I am using the botan dependency in my own dub.selections.json).

By adding the version blocks in this PR, no openssl code is imported when using botan.