### PR TITLE
Fix Vibe.d nightly (phobos/5355: ISharedAllocator)

### DIFF
--- a/core/vibe/internal/allocator.d
+++ b/core/vibe/internal/allocator.d
@@ -1,9 +1,24 @@
 module vibe.internal.allocator;
 
-public import std.experimental.allocator;
+public import std.experimental.allocator : allocatorObject, CAllocatorImpl, dispose,
+	   expandArray, IAllocator, make, makeArray, shrinkArray, theAllocator;
+
 public import std.experimental.allocator.building_blocks.allocator_list;
 public import std.experimental.allocator.building_blocks.null_allocator;
 public import std.experimental.allocator.building_blocks.region;
 public import std.experimental.allocator.building_blocks.stats_collector;
 public import std.experimental.allocator.gc_allocator;
 public import std.experimental.allocator.mallocator;
+
+__gshared IAllocator _processAllocator;
+
+shared static this()
+{
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    _processAllocator = allocatorObject(GCAllocator.instance);
+}
+
+@property IAllocator processAllocator()
+{
+    return _processAllocator;
+}

--- a/utils/vibe/internal/utilallocator.d
+++ b/utils/vibe/internal/utilallocator.d
@@ -111,7 +111,13 @@ final class RegionListAllocator(Allocator, bool leak = false) : IAllocator {
 	override void[] allocateAll() { return null; }
 	override @property Ternary empty() const { return m_fullPools !is null ? Ternary.no : Ternary.yes; }
 	override size_t goodAllocSize(size_t s) { return alignedSize(s); }
-	override Ternary resolveInternalPointer(void* p, ref void[] result) { return Ternary.unknown; }
+
+	import std.traits : Parameters;
+	static if (is(Parameters!(IAllocator.resolveInternalPointer)[0] == const(void*))) {
+		override Ternary resolveInternalPointer(const void* p, ref void[] result) { return Ternary.unknown; }
+	} else {
+		override Ternary resolveInternalPointer(void* p, ref void[] result) { return Ternary.unknown; }
+	}
 	override Ternary owns(void[] b) { return Ternary.unknown; }
 
 

--- a/utils/vibe/internal/utilallocator.d
+++ b/utils/vibe/internal/utilallocator.d
@@ -1,9 +1,22 @@
 module vibe.internal.utilallocator;
 
-public import std.experimental.allocator;
+public import std.experimental.allocator : allocatorObject, CAllocatorImpl, dispose,
+	   expandArray, IAllocator, make, makeArray, shrinkArray, theAllocator;
 public import std.experimental.allocator.mallocator;
 public import std.experimental.allocator.building_blocks.affix_allocator;
 
+__gshared IAllocator _processAllocator;
+
+shared static this()
+{
+    import std.experimental.allocator.gc_allocator : GCAllocator;
+    _processAllocator = allocatorObject(GCAllocator.instance);
+}
+
+@property IAllocator processAllocator()
+{
+    return _processAllocator;
+}
 
 final class RegionListAllocator(Allocator, bool leak = false) : IAllocator {
 	import vibe.internal.memory_legacy : AllocSize, alignedSize;

--- a/utils/vibe/utils/array.d
+++ b/utils/vibe/utils/array.d
@@ -569,7 +569,7 @@ unittest {
 
 struct ArraySet(Key)
 {
-	import std.experimental.allocator : makeArray, expandArray, dispose, processAllocator;
+	import std.experimental.allocator : makeArray, expandArray, dispose;
 	import std.experimental.allocator.building_blocks.affix_allocator : AffixAllocator;
 
 	private {


### PR DESCRIPTION
Since 2.074.0 I could observe at least three regressions:
- [ ] `processAllocator` is now `shared` and an `ISharedAllocator` (https://github.com/dlang/phobos/pull/5355)
- [ ] `resolveInternalPointer` accepts now only`const` (https://github.com/dlang/phobos/pull/5321)
- [x] For running `dub test` and its resulting linking errors (https://github.com/dlang/phobos/pull/5432 has been merged).

This is a dirty workaround against the ISharedAllocator changes and allows vibe.d to be built again.