### PR TITLE
Re-up TTL when opening an existing session

### DIFF
--- a/redis/vibe/db/redis/sessionstore.d
+++ b/redis/vibe/db/redis/sessionstore.d
@@ -47,7 +47,12 @@ final class RedisSessionStore : SessionStore {
 	Session open(string id)
 	{
 		if (m_db.exists(id))
-			return createSessionInstance(id);
+		{
+			auto s = createSessionInstance(id);
+			if (m_expirationTime != Duration.max)
+				m_db.expire(s.id, m_expirationTime);
+			return s;
+		}
 		return Session.init;
 	}
 


### PR DESCRIPTION
When reading the description of expirationTime, it says "The duration without access after which a session expires." To me, this means if you continue to "access" the session, it resets the duration. However, in the implementation, it only sets the TTL once, when the session is created. This means that accessing it does not re-up the timeout.

This fixes that, so now every time you open the session, it also resets the timeout. This is what I would expect session expiration to mean.