### PR TITLE
Remove costly default key

### DIFF
--- a/redis/vibe/db/redis/sessionstore.d
+++ b/redis/vibe/db/redis/sessionstore.d
@@ -37,7 +37,7 @@ final class RedisSessionStore : SessionStore {
 	Session create()
 	{
 		auto s = createSessionInstance();
-		m_db.hmset(s.id, s.id, s.id); // set place holder to avoid create empty hash
+		m_db.hset(s.id, "__SESS", true); // set place holder to avoid create empty hash
 		assert(m_db.exists(s.id));
 		if (m_expirationTime != Duration.max)
 			m_db.expire(s.id, m_expirationTime);


### PR DESCRIPTION
Currently when using redis for sessions, the default key is the session id, and the default value is the session id. The session id's length is 86 characters long. This means that for every session, redis will require 86 * 3 characters minimum of memory, instead of just 86 characters. The key name and data isn't important at all. It's just a minimal default key so the session can be created (redis does not allow empty hashmaps).

This replaces the very long name and value with a small one. While it may not make a huge difference (comes out to about 16.5MB difference if you have 100k sessions), it seems unnecessarily wasteful. In my case, at least, this "default" key is more than 2x larger than all the session data I am storing.