### PR TITLE
Rename the internal processAllocator to vibeThreadAllocator.

### DIFF
--- a/core/vibe/internal/allocator.d
+++ b/core/vibe/internal/allocator.d
@@ -10,15 +10,11 @@ public import std.experimental.allocator.building_blocks.stats_collector;
 public import std.experimental.allocator.gc_allocator;
 public import std.experimental.allocator.mallocator;
 
-__gshared IAllocator _processAllocator;
-
-shared static this()
-{
-    import std.experimental.allocator.gc_allocator : GCAllocator;
-    _processAllocator = allocatorObject(GCAllocator.instance);
-}
-
-@property IAllocator processAllocator()
-{
-    return _processAllocator;
+// NOTE: this needs to be used instead of theAllocator due to Phobos issue 17564
+@property IAllocator vibeThreadAllocator()
+@safe nothrow @nogc {
+	static IAllocator s_threadAllocator;
+	if (!s_threadAllocator)
+		s_threadAllocator = () @trusted { return allocatorObject(GCAllocator.instance); } ();
+	return s_threadAllocator;
 }

--- a/data/vibe/data/bson.d
+++ b/data/vibe/data/bson.d
@@ -1351,7 +1351,7 @@ struct BsonSerializer {
 	this(ubyte[] buffer)
 	@safe {
 		import vibe.internal.utilallocator;
-		m_dst = () @trusted { return AllocAppender!(ubyte[])(processAllocator(), buffer); } ();
+		m_dst = () @trusted { return AllocAppender!(ubyte[])(vibeThreadAllocator(), buffer); } ();
 	}
 
 	@disable this(this);

--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -498,7 +498,7 @@ final class HTTPClient {
 		SysTime connected_time;
 		bool has_body = doRequestWithRetry(requester, false, close_conn, connected_time);
 		m_responding = true;
-		auto res = new HTTPClientResponse(this, has_body, close_conn, () @trusted { return processAllocator(); } (), connected_time);
+		auto res = new HTTPClientResponse(this, has_body, close_conn, () @trusted { return vibeThreadAllocator(); } (), connected_time);
 
 		// proxy implementation
 		if (res.headers.get("Proxy-Authenticate", null) !is null) {

--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -375,7 +375,7 @@ HTTPServerResponse createTestHTTPServerResponse(OutputStream data_sink = null, S
 	}
 	if (!data_sink) data_sink = new NullOutputStream;
 	auto stream = createProxyStream(Stream.init, data_sink);
-	auto ret = new HTTPServerResponse(stream, null, settings, () @trusted { return processAllocator(); } ());
+	auto ret = new HTTPServerResponse(stream, null, settings, () @trusted { return vibeThreadAllocator(); } ());
 	return ret;
 }
 

--- a/inet/vibe/inet/message.d
+++ b/inet/vibe/inet/message.d
@@ -32,7 +32,7 @@ import std.string;
 		alloc = Custom allocator to use for allocating strings
 		rfc822_compatible = Flag indicating that duplicate fields should be merged using a comma
 */
-void parseRFC5322Header(InputStream)(InputStream input, ref InetHeaderMap dst, size_t max_line_length = 1000, IAllocator alloc = processAllocator(), bool rfc822_compatible = true)
+void parseRFC5322Header(InputStream)(InputStream input, ref InetHeaderMap dst, size_t max_line_length = 1000, IAllocator alloc = vibeThreadAllocator(), bool rfc822_compatible = true)
 	if (isInputStream!InputStream)
 {
 	string hdr, hdrvalue;

--- a/stream/vibe/stream/memory.d
+++ b/stream/vibe/stream/memory.d
@@ -16,7 +16,7 @@ import std.array;
 import std.exception;
 import std.typecons;
 
-MemoryOutputStream createMemoryOutputStream(IAllocator alloc = processAllocator())
+MemoryOutputStream createMemoryOutputStream(IAllocator alloc = vibeThreadAllocator())
 @safe nothrow {
 	return new MemoryOutputStream(alloc, true);
 }
@@ -45,7 +45,7 @@ final class MemoryOutputStream : OutputStream {
 	}
 
 	deprecated("Use createMemoryOutputStream isntead.")
-	this(IAllocator alloc = processAllocator())
+	this(IAllocator alloc = vibeThreadAllocator())
 	{
 		this(alloc, true);
 	}

--- a/stream/vibe/stream/openssl.d
+++ b/stream/vibe/stream/openssl.d
@@ -359,12 +359,12 @@ final class OpenSSLStream : TLSStream {
 	private void setClientALPN(string[] alpn_list)
 	{
 		logDebug("SetClientALPN: ", alpn_list);
-		import vibe.internal.allocator : dispose, makeArray, processAllocator;
+		import vibe.internal.allocator : dispose, makeArray, vibeThreadAllocator;
 		ubyte[] alpn;
 		size_t len;
 		foreach (string alpn_val; alpn_list)
 			len += alpn_val.length + 1;
-		alpn = () @trusted { return processAllocator.makeArray!ubyte(len); } ();
+		alpn = () @trusted { return vibeThreadAllocator.makeArray!ubyte(len); } ();
 
 		size_t i;
 		foreach (string alpn_val; alpn_list)
@@ -378,7 +378,7 @@ final class OpenSSLStream : TLSStream {
 		static if (haveALPN)
 			SSL_set_alpn_protos(m_ssl, cast(const char*) alpn.ptr, cast(uint) len);
 
-		() @trusted { processAllocator.dispose(alpn); } ();
+		() @trusted { vibeThreadAllocator.dispose(alpn); } ();
 	}
 }
 

--- a/stream/vibe/stream/operations.d
+++ b/stream/vibe/stream/operations.d
@@ -33,7 +33,7 @@ import std.range : isOutputRange;
 		An exception if either the stream end was hit without hitting a newline first, or
 		if more than max_bytes have been read from the stream.
 */
-ubyte[] readLine(InputStream)(InputStream stream, size_t max_bytes = size_t.max, string linesep = "\r\n", IAllocator alloc = processAllocator()) /*@ufcs*/
+ubyte[] readLine(InputStream)(InputStream stream, size_t max_bytes = size_t.max, string linesep = "\r\n", IAllocator alloc = vibeThreadAllocator()) /*@ufcs*/
 	if (isInputStream!InputStream)
 {
 	auto output = AllocAppender!(ubyte[])(alloc);
@@ -116,7 +116,7 @@ unittest {
 		O(n+m) in typical cases, with n being the length of the scanned input
 		string and m the length of the marker.
 */
-ubyte[] readUntil(InputStream)(InputStream stream, in ubyte[] end_marker, size_t max_bytes = size_t.max, IAllocator alloc = processAllocator()) /*@ufcs*/
+ubyte[] readUntil(InputStream)(InputStream stream, in ubyte[] end_marker, size_t max_bytes = size_t.max, IAllocator alloc = vibeThreadAllocator()) /*@ufcs*/
 @safe	if (isInputStream!InputStream)
 {
 	auto output = AllocAppender!(ubyte[])(alloc);

--- a/utils/vibe/internal/utilallocator.d
+++ b/utils/vibe/internal/utilallocator.d
@@ -5,17 +5,14 @@ public import std.experimental.allocator : allocatorObject, CAllocatorImpl, disp
 public import std.experimental.allocator.mallocator;
 public import std.experimental.allocator.building_blocks.affix_allocator;
 
-__gshared IAllocator _processAllocator;
-
-shared static this()
-{
-    import std.experimental.allocator.gc_allocator : GCAllocator;
-    _processAllocator = allocatorObject(GCAllocator.instance);
-}
-
-@property IAllocator processAllocator()
-{
-    return _processAllocator;
+// NOTE: this needs to be used instead of theAllocator due to Phobos issue 17564
+@property IAllocator vibeThreadAllocator()
+@safe nothrow @nogc {
+	import std.experimental.allocator.gc_allocator;
+	static IAllocator s_threadAllocator;
+	if (!s_threadAllocator)
+		s_threadAllocator = () @trusted { return allocatorObject(GCAllocator.instance); } ();
+	return s_threadAllocator;
 }
 
 final class RegionListAllocator(Allocator, bool leak = false) : IAllocator {

--- a/utils/vibe/utils/array.d
+++ b/utils/vibe/utils/array.d
@@ -711,8 +711,8 @@ struct ArraySet(Key)
 			static if (__VERSION__ < 2074) auto palloc = m_allocator.parent;
 			else auto palloc = m_allocator._parent;
 			if (!palloc) {
-				assert(processAllocator !is null, "No theAllocator set!?");
-				m_allocator = AllocatorType(AW(processAllocator));
+				assert(vibeThreadAllocator !is null, "No theAllocator set!?");
+				m_allocator = AllocatorType(AW(vibeThreadAllocator));
 			}
 		} catch (Exception e) assert(false, e.msg); // should never throw
 		return m_allocator;

--- a/utils/vibe/utils/hashmap.d
+++ b/utils/vibe/utils/hashmap.d
@@ -255,7 +255,7 @@ struct HashMap(TKey, TValue, Traits = DefaultHashMapTraits!TKey)
 				static if (__VERSION__ < 2074) auto palloc = m_allocator.parent;
 				else auto palloc = m_allocator._parent;
 			if (!palloc) {
-				try m_allocator = typeof(m_allocator)(AW(processAllocator()));
+				try m_allocator = typeof(m_allocator)(AW(vibeThreadAllocator()));
 				catch (Exception e) assert(false, e.msg);
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
Just to avoid confusion or name clashes with the original from `std.experimental.allocator`. Also uses lazy initialization to avoid potential module constructor cycles (not currently an issue!).