### PR TITLE
parseJsonBody with readALLUTF8 instead of readAll + cast's

### DIFF
--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -2020,7 +2020,7 @@ private bool handleRequest(InterfaceProxy!Stream http_stream, TCPConnection tcp_
 
 		if (settings.options & HTTPServerOption.parseJsonBody) {
 			if (icmp2(req.contentType, "application/json") == 0 || icmp2(req.contentType, "application/vnd.api+json") == 0 ) {
-				auto bodyStr = () @trusted { return cast(string)req.bodyReader.readAll(); } ();
+				auto bodyStr = req.bodyReader.readAllUTF8;
 				if (!bodyStr.empty) req.json = parseJson(bodyStr);
 			}
 		}


### PR DESCRIPTION
https://github.com/rejectedsoftware/vibe.d/pull/1677

FWIW in theory JSON can be encoded in UTF-16 and UTF-32 (see references below), but the current implementation doesn't handle this as well, it just silently assumes UTF-8.

References
---------------

https://tools.ietf.org/html/rfc7159#section-8

>   JSON text SHALL be encoded in UTF-8, UTF-16, or UTF-32.  The default
   encoding is UTF-8, and JSON texts that are encoded in UTF-8 are
   interoperable in the sense that they will be read successfully by the
   maximum number of implementations; there are many implementations
   that cannot successfully read texts in other encodings (such as
   UTF-16 and UTF-32).

https://www.ietf.org/rfc/rfc4627.txt

 >  JSON text SHALL be encoded in Unicode.  The default encoding is
   UTF-8.

>   Since the first two characters of a JSON text will always be ASCII
   characters [RFC0020], it is possible to determine whether an octet
   stream is UTF-8, UTF-16 (BE or LE), or UTF-32 (BE or LE) by looking
   at the pattern of nulls in the first four octets.

           00 00 00 xx  UTF-32BE
           00 xx 00 xx  UTF-16BE
           xx 00 00 00  UTF-32LE
           xx 00 xx 00  UTF-16LE
           xx xx xx xx  UTF-8