### PR TITLE
Allow to run CodeCov on Vibe.d

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+# Documentation: https://github.com/codecov/support/wiki/codecov.yml
+
+coverage:
+  precision: 3
+  round: down
+  range: 80...100
+
+  status:
+    # Learn more at https://codecov.io/docs#yaml_default_commit_status
+    project: true
+    patch: true
+    changes: false
+
+comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.lib
 *.dll
 .*.sw*
+*.lst
 
 docs.json
 /docs/index.html
@@ -25,6 +26,7 @@ vibe-d
 tests/*/tests
 __test__*__
 vibe-d-test*
+vibe-d-*-test*
 
 # Examples
 examples/app_skeleton/__test__library__

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ env:
   - VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
 
 matrix:
+  include:
+    - d: dmd
+      # https://issues.dlang.org/show_bug.cgi?id=13742
+      env: DUB_ARGS="--build=unittest-cov --build-mode=singleFile"
   exclude:
     - d: ldc-1.0.0
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
@@ -45,3 +49,5 @@ matrix:
       env: VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0
 
 script: ./travis-ci.sh
+after_success:
+ - bash <(curl -s https://codecov.io/bash)

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -2,6 +2,8 @@
 
 set -e -x -o pipefail
 
+DUB_ARGS=${DUB_ARGS:-}
+
 ./scripts/test_version.sh
 
 # Check for trailing whitespace"
@@ -17,19 +19,19 @@ if [ "$DC" == "dmd" ]; then
 	dub clean --all-packages
 fi
 
-dub test :data --compiler=$DC
-dub test :core --compiler=$DC --config=${VIBED_DRIVER=libevent}
-dub test :mongodb --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :redis --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :diet --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :web --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :utils --compiler=$DC
-dub test :http --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :mail --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :stream --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :crypto --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :textfilter --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
-dub test :inet --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent}
+dub test :data --compiler=$DC $DUB_ARGS
+dub test :core --compiler=$DC --config=${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :mongodb --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :redis --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :diet --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :web --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :utils --compiler=$DC $DUB_ARGS
+dub test :http --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :mail --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :stream --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :crypto --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :textfilter --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
+dub test :inet --compiler=$DC --override-config=vibe-d:core/${VIBED_DRIVER=libevent} $DUB_ARGS
 dub clean --all-packages
 
 if [ ${BUILD_EXAMPLE=1} -eq 1 ]; then


### PR DESCRIPTION
This allows coverage from simple test suite as a first step.

IIRC CodeCov will send the notifications automatically, but it's better to enable them as web hook and GitHub integration (better stability).

Currently this will fail, because trailing whitespace managed to sneak in & then the test suite gets prematurely stopped.