### PR TITLE
Remove deprecated stdc import

### DIFF
--- a/core/vibe/core/core.d
+++ b/core/vibe/core/core.d
@@ -1670,7 +1670,7 @@ shared static this()
 		static if (need_wsa) {
 			logTrace("init winsock");
 			// initialize WinSock2
-			import std.c.windows.winsock;
+			import core.sys.windows.winsock2;
 			WSADATA data;
 			WSAStartup(0x0202, &data);
 

--- a/core/vibe/core/drivers/libevent2.d
+++ b/core/vibe/core/drivers/libevent2.d
@@ -57,7 +57,7 @@ version(Windows)
 	static if (__VERSION__ >= 2070)
 		import core.sys.windows.winsock2;
 	else
-		import std.c.windows.winsock;
+		import core.sys.windows.winsock2;
 
 	alias EWOULDBLOCK = WSAEWOULDBLOCK;
 }

--- a/core/vibe/core/drivers/libevent2_tcp.d
+++ b/core/vibe/core/drivers/libevent2_tcp.d
@@ -45,11 +45,11 @@ private {
 			alias INADDR_ANY = core.sys.windows.winsock2.INADDR_ANY;
 			alias IN6ADDR_ANY = core.sys.windows.winsock2.IN6ADDR_ANY;
 		} else {
-			import std.c.windows.winsock;
+			import core.sys.windows.winsock2;
 			// make some neccessary parts of the socket interface public
-			alias in6_addr = std.c.windows.winsock.in6_addr;
-			alias INADDR_ANY = std.c.windows.winsock.INADDR_ANY;
-			alias IN6ADDR_ANY = std.c.windows.winsock.IN6ADDR_ANY;
+			alias in6_addr = core.sys.windows.winsock2.in6_addr;
+			alias INADDR_ANY = core.sys.windows.winsock2.INADDR_ANY;
+			alias IN6ADDR_ANY = core.sys.windows.winsock2.IN6ADDR_ANY;
 		}
 
 		enum EWOULDBLOCK = WSAEWOULDBLOCK;

--- a/core/vibe/core/drivers/threadedfile.d
+++ b/core/vibe/core/drivers/threadedfile.d
@@ -27,7 +27,7 @@ version(Windows){
 	static if (__VERSION__ >= 2070)
 		import core.sys.windows.stat;
 	else
-		import std.c.windows.stat;
+		import core.sys.windows.stat;
 
 	private {
 		// TODO: use CreateFile/HANDLE instead of the Posix API on Windows

--- a/core/vibe/core/drivers/utils.d
+++ b/core/vibe/core/drivers/utils.d
@@ -14,8 +14,8 @@ version (Windows) {
 		import core.sys.windows.windows;
 		import core.sys.windows.winsock2;
 	} else {
-		import std.c.windows.windows;
-		import std.c.windows.winsock;
+		import core.sys.windows.windows;
+		import core.sys.windows.winsock2;
 	}
 
 	alias EWOULDBLOCK = WSAEWOULDBLOCK;

--- a/core/vibe/core/drivers/win32.d
+++ b/core/vibe/core/drivers/win32.d
@@ -37,8 +37,8 @@ static if (__VERSION__ >= 2070) {
 	import core.sys.windows.windows;
 	import core.sys.windows.winsock2;
 } else {
-	import std.c.windows.windows;
-	import std.c.windows.winsock;
+	import core.sys.windows.windows;
+	import core.sys.windows.winsock2;
 }
 
 enum WM_USER_SIGNAL = WM_USER+101;

--- a/core/vibe/core/net.d
+++ b/core/vibe/core/net.d
@@ -157,7 +157,7 @@ struct NetworkAddress {
 		static if (__VERSION__ >= 2070)
 			import core.sys.windows.winsock2 : sockaddr, sockaddr_in, sockaddr_in6;
 		else
-			import std.c.windows.winsock : sockaddr, sockaddr_in, sockaddr_in6;
+			import core.sys.windows.winsock2 : sockaddr, sockaddr_in, sockaddr_in6;
 	}
 	version(Posix)
 	{

--- a/crypto/vibe/crypto/cryptorand.d
+++ b/crypto/vibe/crypto/cryptorand.d
@@ -475,7 +475,7 @@ version(Windows)
 	static if (__VERSION__ >= 2070) {
 		import core.sys.windows.windows;
 	} else {
-		import std.c.windows.windows;
+		import core.sys.windows.windows;
 	}
 
 	private extern(Windows) nothrow

--- a/stream/vibe/stream/openssl.d
+++ b/stream/vibe/stream/openssl.d
@@ -123,7 +123,7 @@ final class OpenSSLStream : TLSStream {
 				auto result = () @trusted { return SSL_get_verify_result(m_tls); } ();
 				if (result == X509_V_OK && (ctx.peerValidationMode & TLSPeerValidationMode.checkPeer)) {
 					if (!verifyCertName(peer, GENERAL_NAME.GEN_DNS, vdata.peerName)) {
-						version(Windows) import std.c.windows.winsock;
+						version(Windows) import core.sys.windows.winsock2;
 						else import core.sys.posix.netinet.in_;
 
 						logDiagnostic("TLS peer name '%s' couldn't be verified, trying IP address.", vdata.peerName);

--- a/utils/vibe/internal/win32.d
+++ b/utils/vibe/internal/win32.d
@@ -8,8 +8,8 @@ static if (__VERSION__ >= 2070) {
 	public import core.sys.windows.winsock2;
 } else {
 	public import core.sys.windows.windows;
-	public import std.c.windows.windows;
-	public import std.c.windows.winsock;
+	public import core.sys.windows.windows;
+	public import core.sys.windows.winsock2;
 
 	extern(System) nothrow:
 	enum HWND HWND_MESSAGE = cast(HWND)-3;


### PR DESCRIPTION
Probably not seen because no developers actively compiles Vibe.d on Windows and looked at the deprecation warnings.

See also: https://github.com/dlang/phobos/pull/5532

I am doing this blindly and relying on AppVeyor for testing.