### PR TITLE
Set the coverageDestPath for all files to the root folder

### DIFF
--- a/core/vibe/core/core.d
+++ b/core/vibe/core/core.d
@@ -2062,6 +2062,9 @@ unittest {
 // a long version
 version(VibedSetCoverageMerge)
 shared static this() {
-	import core.runtime : dmd_coverSetMerge;
+	import core.runtime : dmd_coverDestPath, dmd_coverSetMerge;
+	import std.path : buildPath, dirName;
 	dmd_coverSetMerge(true);
+	static immutable coverageDestDir = __FILE_FULL_PATH__.dirName.buildPath("..", "..", "..");
+	dmd_coverDestPath(coverageDestDir);
 }


### PR DESCRIPTION
Follow-up to https://github.com/rejectedsoftware/vibe.d/pull/1810#issuecomment-312599635

Not sure whether this helps to improve things or if CodeCov already merges the lst files automagically.