### PR TITLE
Added unix domain socket support to http.proxy

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -1118,7 +1118,7 @@ final class HTTPClientResponse : HTTPResponse {
 }
 
 /** Returns clean host string. In case of unix socket it performs urlDecode on host. */
-private auto getFilteredHost(URL url)
+package auto getFilteredHost(URL url)
 {
 	version(UnixSocket)
 	{


### PR DESCRIPTION
- changed the HTTPReverseProxySettings class to hold a destination URL instead
of (host, port)
- added reverseProxyRequest overload with URL
- updated the proxy handler logic
- made getFilteredHost() public