### PR TITLE
Allow listenHTTP to accept a convenience setting string

### DIFF
--- a/tests/vibe.http.server.listenHTTP/dub.sdl
+++ b/tests/vibe.http.server.listenHTTP/dub.sdl
@@ -1,0 +1,4 @@
+name "tests"
+description "listenHTTP tests"
+dependency "vibe-d:http" path="../../"
+versions "VibeDefaultMain"

--- a/tests/vibe.http.server.listenHTTP/source/app.d
+++ b/tests/vibe.http.server.listenHTTP/source/app.d
@@ -1,0 +1,22 @@
+import vibe.core.core;
+import vibe.core.core;
+import vibe.core.log;
+import vibe.http.client;
+import vibe.http.server;
+import vibe.stream.operations : readAllUTF8;
+
+shared static this()
+{
+	listenHTTP(":11721", (scope req, scope res) {
+		res.writeBody("Hello world.");
+	});
+
+	runTask({
+		scope (exit) exitEventLoop();
+
+		auto res = requestHTTP("http://0.0.0.0:11721");
+		assert(res.statusCode == HTTPStatus.ok);
+		assert(res.bodyReader.readAllUTF8 == "Hello world.");
+		logInfo("All web tests succeeded.");
+	});
+}


### PR DESCRIPTION
Follow-up to https://github.com/rejectedsoftware/vibe.d/pull/1810

Now that `HTTPServerSettings` accept a string, `listenHTTP` can do so as well :tada: 

Instead of adding five new overloads, I opted for templates.