### PR TITLE
Json.opIndex: Document behavior if key is not found

### DIFF
--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -326,6 +326,7 @@ struct Json {
 	/**
 		Allows direct indexing of object typed JSON values using a string as
 		the key.
+		Returns an object of Type.undefined if the key was not found.
 	*/
 	const(Json) opIndex(string key)
 	const {
@@ -365,6 +366,7 @@ struct Json {
 		assert(value["a"] == 1);
 		assert(value["b"] == true);
 		assert(value["c"] == "foo");
+		assert(value["not-existing"].type() == Type.undefined);
 	}
 
 	/**

--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -326,7 +326,7 @@ struct Json {
 	/**
 		Allows direct indexing of object typed JSON values using a string as
 		the key.
-		
+
 		Returns an object of `Type.undefined` if the key was not found.
 	*/
 	const(Json) opIndex(string key)

--- a/data/vibe/data/json.d
+++ b/data/vibe/data/json.d
@@ -326,7 +326,8 @@ struct Json {
 	/**
 		Allows direct indexing of object typed JSON values using a string as
 		the key.
-		Returns an object of Type.undefined if the key was not found.
+		
+		Returns an object of `Type.undefined` if the key was not found.
 	*/
 	const(Json) opIndex(string key)
 	const {


### PR DESCRIPTION
Documented that it returns Type.undefined objects if the key wasn't found.
Also added an example to the unittest.