### PR TITLE
Let urlDecode return a slice if possible.

### DIFF
--- a/textfilter/vibe/textfilter/urlencode.d
+++ b/textfilter/vibe/textfilter/urlencode.d
@@ -22,24 +22,9 @@ import std.format;
  */
 T[] urlEncode(T)(T[] str, const(char)[] allowed_chars = null) if (is(T[] : const(char)[]))
 {
-	foreach (char c; str) {
-		switch(c) {
-			case '-':
-			case '.':
-			case '0': .. case '9':
-			case 'A': .. case 'Z':
-			case '_':
-			case 'a': .. case 'z':
-			case '~':
-				break;
-			default:
-				auto dst = appender!(T[]);
-				dst.reserve(str.length);
-				filterURLEncode(dst, str, allowed_chars);
-				return dst.data;
-		}
-	}
-	return str;
+	auto dst = StringSliceAppender!(T[])(str);
+	filterURLEncode(dst, str, allowed_chars);
+	return dst.data;
 }
 
 @safe unittest {
@@ -67,7 +52,7 @@ private auto isCorrectHexNum(const(char)[] str)
 bool isURLEncoded(const(char)[] str, const(char)[] reserved_chars = null)
 @safe {
 	for (size_t i = 0; i < str.length; i++) {
-		switch(str[i]) {
+		switch (str[i]) {
 			case '-':
 			case '.':
 			case '0': .. case '9':
@@ -105,8 +90,7 @@ bool isURLEncoded(const(char)[] str, const(char)[] reserved_chars = null)
 T[] urlDecode(T)(T[] str) if (is(T[] : const(char)[]))
 {
 	if (!str.anyOf("%")) return str;
-	auto dst = appender!(T[]);
-	dst.reserve(str.length);
+	auto dst = StringSliceAppender!(T[])(str);
 	filterURLDecode(dst, str);
 	return dst.data;
 }
@@ -121,8 +105,7 @@ T[] urlDecode(T)(T[] str) if (is(T[] : const(char)[]))
 */
 T[] formEncode(T)(T[] str, const(char)[] allowed_chars = null) if (is(T[] : const(char)[]))
 {
-	auto dst = appender!(T[]);
-	dst.reserve(str.length);
+	auto dst = StringSliceAppender!(T[])(str);
 	filterURLEncode(dst, str, allowed_chars, true);
 	return dst.data;
 }
@@ -135,8 +118,7 @@ T[] formEncode(T)(T[] str, const(char)[] allowed_chars = null) if (is(T[] : cons
 T[] formDecode(T)(T[] str) if (is(T[] : const(char)[]))
 {
 	if (!str.anyOf("%+")) return str;
-	auto dst = appender!string();
-	dst.reserve(str.length);
+	auto dst = StringSliceAppender!(T[])(str);
 	filterURLDecode(dst, str, true);
 	return dst.data;
 }
@@ -147,8 +129,17 @@ void filterURLEncode(R)(ref R dst, const(char)[] str,
                         const(char)[] allowed_chars = null,
                         bool form_encoding = false)
 {
-	while( str.length > 0 ) {
-		switch(str[0]) {
+	while (str.length > 0) {
+		switch (str[0]) {
+			default:
+				if (allowed_chars.canFind(str[0])) dst.put(str[0]);
+				else {
+					static if (is(typeof({ R a, b; b = a; })))
+						formattedWrite(dst, "%%%02X", str[0]);
+					else
+						formattedWrite(() @trusted { return &dst; } (), "%%%02X", str[0]);
+				}
+				break;
 			case ' ':
 				if (form_encoding) {
 					dst.put('+');
@@ -161,9 +152,6 @@ void filterURLEncode(R)(ref R dst, const(char)[] str,
 			case '-': case '_': case '.': case '~':
 				dst.put(str[0]);
 				break;
-			default:
-				if (allowed_chars.canFind(str[0])) dst.put(str[0]);
-				else formattedWrite(dst, "%%%02X", str[0]);
 		}
 		str = str[1 .. $];
 	}
@@ -205,7 +193,7 @@ void filterURLDecode(R)(ref R dst, const(char)[] str, bool form_encoding = false
 	assert(urlEncode("\r\n") == "%0D%0A"); // github #65
 	assert(urlEncode("This-is~a_test") == "This-is~a_test");
 	assert(urlEncode("This is a test") == "This%20is%20a%20test");
-	assert(urlEncode("This{is}test") == "This%7Bis%7Dtest", urlEncode("This{is}test"));
+	assert(urlEncode("This{is}test") == "This%7Bis%7Dtest");
 	assert(formEncode("This is a test") == "This+is+a+test");
 	assert(formEncode("this/test", "/") == "this/test");
 	assert(formEncode("this/test") == "this%2Ftest");
@@ -220,4 +208,100 @@ void filterURLDecode(R)(ref R dst, const(char)[] str, bool form_encoding = false
 	string aenc = urlEncode(a);
 	assert(aenc == "This~is%20a-test%21%0D%0AHello%2C%20W%C3%B6rld..%20");
 	assert(urlDecode(urlEncode(a)) == a);
+}
+
+
+private struct StringSliceAppender(S) {
+	private {
+		Appender!S m_appender;
+		S m_source;
+		size_t m_prefixLength;
+	}
+
+	this(S source)
+	{
+		m_source = source;
+		if (m_source.length == 0)
+			m_appender = appender!S();
+	}
+
+	@disable this(this);
+
+	void put(char ch)
+	{
+		if (m_source.length) {
+			if (m_prefixLength < m_source.length && m_source[m_prefixLength] == ch) {
+				m_prefixLength++;
+				return;
+			}
+
+			m_appender = appender!S();
+			m_appender.put(m_source[0 .. m_prefixLength]);
+			m_appender.put(ch);
+			m_source = S.init;
+		} else m_appender.put(ch);
+	}
+
+	void put(S s)
+	{
+		if (m_source.length) {
+			foreach (char ch; s)
+				put(ch);
+		} else m_appender.put(s);
+	}
+
+	void put(dchar ch)
+	{
+		import std.encoding : encode;
+		char[6] chars;
+		auto n = encode(ch, chars[]);
+		foreach (char c; chars[0 .. n]) put(c);
+	}
+
+	@property S data()
+	{
+		return m_source.length ? m_source[0 .. m_prefixLength] : m_appender.data;
+	}
+}
+
+@safe unittest {
+	string s = "foo";
+	auto a = StringSliceAppender!string(s);
+	a.put("f"); assert(a.data == "f"); assert(a.data.ptr is s.ptr);
+	a.put('o'); assert(a.data == "fo"); assert(a.data.ptr is s.ptr);
+	a.put('o'); assert(a.data == "foo"); assert(a.data.ptr is s.ptr);
+	a.put('ä'); assert(a.data == "fooä");
+
+	a = StringSliceAppender!string(s);
+	a.put('f'); assert(a.data == "f"); assert(a.data.ptr is s.ptr);
+	a.put("oobar"); assert(a.data == "foobar");
+
+	a = StringSliceAppender!string(s);
+	a.put(cast(dchar)'f'); assert(a.data == "f"); assert(a.data.ptr is s.ptr);
+	a.put('b'); assert(a.data == "fb");
+
+	a = StringSliceAppender!string(s);
+	a.put('f'); assert(a.data == "f"); assert(a.data.ptr is s.ptr);
+	a.put("b"); assert(a.data == "fb");
+
+	a = StringSliceAppender!string(s);
+	a.put('f'); assert(a.data == "f"); assert(a.data.ptr is s.ptr);
+	a.put("ä"); assert(a.data == "fä");
+
+	a = StringSliceAppender!string(s);
+	a.put("bar"); assert(a.data == "bar");
+
+	a = StringSliceAppender!string(s);
+	a.put('b'); assert(a.data == "b");
+
+	a = StringSliceAppender!string(s);
+	a.put('ä'); assert(a.data == "ä");
+
+	a = StringSliceAppender!string(s);
+	a.put("foo"); assert(a.data == "foo"); assert(a.data.ptr is s.ptr);
+	a.put("bar"); assert(a.data == "foobar");
+
+	a = StringSliceAppender!string(s);
+	a.put("foo"); assert(a.data == "foo"); assert(a.data.ptr is s.ptr);
+	a.put('b'); assert(a.data == "foob");
 }

--- a/textfilter/vibe/textfilter/urlencode.d
+++ b/textfilter/vibe/textfilter/urlencode.d
@@ -254,7 +254,10 @@ private struct StringSliceAppender(S) {
 	{
 		import std.encoding : encode;
 		char[6] chars;
-		auto n = encode(ch, chars[]);
+		static if (__VERSION__ < 2072)
+			auto n = () @trusted { return encode(ch, chars[]); } ();
+		else
+			auto n = encode(ch, chars[]);
 		foreach (char c; chars[0 .. n]) put(c);
 	}
 


### PR DESCRIPTION
In case of no escape sequences, the input string will be returned. This also replaces the similar logic for urlEncode by a generic approach. See also #1635.