### PR TITLE
Use larger streamOutputRange chunk size in the HTTP package.

### DIFF
--- a/http/vibe/http/client.d
+++ b/http/vibe/http/client.d
@@ -737,7 +737,7 @@ final class HTTPClientRequest : HTTPRequest {
 			headers["Content-Length"] = clengthString(length);
 		}
 
-		auto rng = streamOutputRange(bodyWriter);
+		auto rng = streamOutputRange!1024(bodyWriter);
 		() @trusted { serializeToJson(&rng, data); } ();
 		rng.flush();
 		finalize();
@@ -756,7 +756,7 @@ final class HTTPClientRequest : HTTPRequest {
 		counter.formEncode(key_value_map);
 		headers["Content-Length"] = clengthString(length);
 		headers["Content-Type"] = "application/x-www-form-urlencoded";
-		auto dst = streamOutputRange(bodyWriter);
+		auto dst = streamOutputRange!1024(bodyWriter);
 		() @trusted { return &dst; } ().formEncode(key_value_map);
 	}
 
@@ -808,7 +808,7 @@ final class HTTPClientRequest : HTTPRequest {
 		assert(!m_headerWritten, "HTTPClient tried to write headers twice.");
 		m_headerWritten = true;
 
-		auto output = streamOutputRange(m_conn);
+		auto output = streamOutputRange!1024(m_conn);
 
 		formattedWrite(() @trusted { return &output; } (), "%s %s %s\r\n", httpMethodString(method), requestURL, getHTTPVersionString(httpVersion));
 		logTrace("--------------------");

--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -277,7 +277,7 @@ void setVibeDistHost(string host, ushort port)
 	} else {
 		import vibe.stream.wrapper : streamOutputRange;
 		import diet.html : compileHTMLDietFile;
-		auto output = streamOutputRange(res.bodyWriter);
+		auto output = streamOutputRange!1024(res.bodyWriter);
 		compileHTMLDietFile!(template_file, ALIASES, DefaultFilters)(output);
 	}
 }
@@ -1276,7 +1276,7 @@ final class HTTPServerResponse : HTTPResponse {
 			headers["Content-Length"] = formatAlloc(m_requestAlloc, "%d", length);
 		}
 
-		auto rng = streamOutputRange(bodyWriter);
+		auto rng = streamOutputRange!1024(bodyWriter);
 		static if (PRETTY) serializeToPrettyJson(() @trusted { return &rng; } (), data);
 		else serializeToJson(() @trusted { return &rng; } (), data);
 	}
@@ -1583,7 +1583,7 @@ final class HTTPServerResponse : HTTPResponse {
 
 		assert(!m_bodyWriter && !m_headerWritten, "Try to write header after body has already begun.");
 		m_headerWritten = true;
-		auto dst = StreamOutputRange!(InterfaceProxy!Stream)(m_conn);
+		auto dst = streamOutputRange!1024(m_conn);
 
 		void writeLine(T...)(string fmt, T args)
 		@safe {

--- a/stream/vibe/stream/wrapper.d
+++ b/stream/vibe/stream/wrapper.d
@@ -289,7 +289,7 @@ struct StreamInputRange {
 */
 StreamOutputRange!OutputStream StreamOutputRange()(OutputStream stream) { return StreamOutputRange!OutputStream(stream); }
 /// ditto
-struct StreamOutputRange(OutputStream)
+struct StreamOutputRange(OutputStream, size_t buffer_size = 256)
 	if (isOutputStream!OutputStream)
 {
 @safe:
@@ -297,7 +297,7 @@ struct StreamOutputRange(OutputStream)
 	private {
 		OutputStream m_stream;
 		size_t m_fill = 0;
-		ubyte[256] m_data = void;
+		ubyte[buffer_size] m_data = void;
 	}
 
 	@disable this(this);
@@ -362,10 +362,10 @@ struct StreamOutputRange(OutputStream)
 	void put(const(dchar)[] elems) { foreach( ch; elems ) put(ch); }
 }
 /// ditto
-auto streamOutputRange(OutputStream)(OutputStream stream)
+auto streamOutputRange(size_t buffer_size = 256, OutputStream)(OutputStream stream)
 	if (isOutputStream!OutputStream)
 {
-	return StreamOutputRange!OutputStream(stream);
+	return StreamOutputRange!(OutputStream, buffer_size)(stream);
 }
 
 unittest {


### PR DESCRIPTION
This is closer to the typical ~1500 byte MTU of ethernet connections and already reduces the protocol overhead for range sourced bodies considerably. In the future, the buffer should be even larger, but the required memory shouldn't be allocated on the stack to keep the typical stack use per request low (avoids committing more memory pages for the stack) . A per-thread freelist or the request allocator could be used instead.