### PR TITLE
Initialize variables in shared static this()

### DIFF
--- a/mongodb/vibe/db/mongo/sasl.d
+++ b/mongodb/vibe/db/mongo/sasl.d
@@ -20,7 +20,12 @@ import vibe.crypto.cryptorand;
 
 @safe:
 
-private SHA1HashMixerRNG g_rng;
+private SHA1HashMixerRNG g_rng()
+{
+	static SHA1HashMixerRNG m_rng;
+	if (!m_rng) m_rng = new SHA1HashMixerRNG;
+	return m_rng;
+}
 
 package struct ScramState
 {
@@ -149,9 +154,4 @@ private DigestType!SHA1 pbkdf2(const ubyte[] password, const ubyte[] salt, int i
 		}
 	}
 	return current;
-}
-
-static this()
-{
-	g_rng = new SHA1HashMixerRNG();
 }


### PR DESCRIPTION
If `connectMongo` with SASL (e.g. SCRAM) is called in a static shared constructor, it will nicely segfault.