### PR TITLE
Fix #1785 - Use SCRAM-SHA-1 as default for MongoDB

### DIFF
--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -184,10 +184,20 @@ final class MongoConnection {
 		m_bytesRead = 0;
 		if(m_settings.digest != string.init)
 		{
-			if (m_settings.authMechanism == MongoAuthMechanism.scramSHA1)
-				scramAuthenticate();
-			else
+			if (m_settings.authMechanism == MongoAuthMechanism.none)
 				authenticate();
+			else {
+				/**
+				SCRAM-SHA-1 was released in March 2015 and on a properly
+				configured Mongo instance Authentication.none is disabled.
+				However, as a fallback to avoid breakage with old setups,
+				no authentication is tried in case of an error.
+				*/
+				try
+					scramAuthenticate();
+				catch (MongoAuthException e)
+					authenticate();
+			}
 
 		}
 		else if (m_settings.sslPEMKeyFile != null && m_settings.username != null)

--- a/mongodb/vibe/db/mongo/mongo.d
+++ b/mongodb/vibe/db/mongo/mongo.d
@@ -41,12 +41,7 @@ import std.algorithm;
 
 	Authentication:
 		Authenticated connections are supported by using a URL connection string
-		such as "mongodb://user:password@host". Note that the driver currently
-		only supports the "MongoDB-CR" authentication mechanism. Since new
-		MongoDB versions, starting with 3.0, default to the new "SCRAM-SHA-1"
-		method, it is necessary to manually switch to the old method. See
-		$(WEB http://stackoverflow.com/questions/29006887/mongodb-cr-authentication-failed)
-		for more information.
+		such as "mongodb://user:password@host". SCRAM-SHA-1 is used by default.
 
 	Examples:
 		---


### PR DESCRIPTION
Added the fallback just to be sure to avoid breakage.