### PR TITLE
Added web interface language() property

### DIFF
--- a/web/vibe/web/web.d
+++ b/web/vibe/web/web.d
@@ -486,6 +486,17 @@ unittest {
 }
 
 /**
+	Returns the agreed upon language.
+
+	Note that this may only be called from a function/method
+	registered using registerWebInterface.
+*/
+string language() @property
+{
+	return s_requestContext.language;
+}
+
+/**
 	Terminates the currently active session (if any).
 
 	Note that this may only be called from a function/method


### PR DESCRIPTION
Because s_requestContext was private you couldn't really get the language that was chosen without including the request as argument and then calling the translation context's determine language function.