### PR TITLE
fix check for redefining symbol SO_REUSEPORT

### DIFF
--- a/core/vibe/core/drivers/utils.d
+++ b/core/vibe/core/drivers/utils.d
@@ -44,6 +44,7 @@ version (Windows) {
 } else alias SystemSocketException = ErrnoException;
 
 version (linux) {
+	import core.sys.posix.sys.socket;
 	static if (!is(typeof(SO_REUSEPORT))) {
 		enum { SO_REUSEPORT = 15 }
 	}


### PR DESCRIPTION
SO_REUSEPORT is defined in core.sys.posix.sys.socket by https://github.com/dlang/druntime/pull/1879, producing an ambiguity error.

Without an import, what symbol does the existing version check against?