### PR TITLE
Use raw Content-Type in parseFormAndFiles

### DIFF
--- a/http/vibe/http/server.d
+++ b/http/vibe/http/server.d
@@ -923,7 +923,7 @@ final class HTTPServerRequest : HTTPRequest {
 
 		private void parseFormAndFiles() @safe {
 			_form = FormFields.init;
-			parseFormData(_form, _files, contentType, bodyReader, MaxHTTPHeaderLineLength);
+			parseFormData(_form, _files, headers["Content-Type"], bodyReader, MaxHTTPHeaderLineLength);
 		}
 
 		/** Contains information about any uploaded file for a HTML _form request.


### PR DESCRIPTION
fix #1872, now parsing files works again