### PR TITLE
meson: Always build with Diet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ __dummy.html
 dub.selections.json
 
 # Auto-downloaded 3rd-party
-lib/subprojects/
+lib/subprojects/diet/
+lib/subprojects/libevent/
+lib/subprojects/openssl/
 
 # Mono-D files
 *.userprefs

--- a/http/meson.build
+++ b/http/meson.build
@@ -50,7 +50,8 @@ vibe_http_lib = library('vibe-http',
                               vibe_crypto_src_dir,
                               openssl_inc],
         install: true,
-        dependencies: [zlib_dep],
+        dependencies: [zlib_dep,
+                       diet_dep],
         link_with: [http_link_with],
         version: project_version,
         soversion: project_soversion
@@ -59,6 +60,7 @@ pkgc.generate(name: 'vibe-http',
               libraries: [vibe_http_lib] + http_link_with,
               subdirs: 'd/vibe',
               version: project_version,
+              requires: 'diet',
               description: 'Vibe HTTP server and client implementation and higher level HTTP functionality'
 )
 
@@ -79,7 +81,8 @@ vibe_test_http_exe = executable('vibe-test_http',
     dependencies: [zlib_dep,
                    crypto_dep,
                    ssl_dep,
-                   libevent_dep],
+                   libevent_dep,
+                   diet_dep],
     link_with: [http_link_with],
     d_args: meson.get_compiler('d').unittest_args(),
     link_args: '-main'

--- a/lib/subprojects/diet.wrap
+++ b/lib/subprojects/diet.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory=diet
+url=https://github.com/rejectedsoftware/diet-ng
+revision=head

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('Vibe.d', 'd',
     meson_version: '>=0.40',
+    subproject_dir: 'lib/subprojects',
     license: 'MIT',
     version: '0.8.1'
 )
@@ -22,9 +23,43 @@ crypto_dep = dependency('libcrypto')
 ssl_dep = dependency('libssl')
 libevent_dep = dependency('libevent')
 
+#
+# Compiler flags
+#
+flag_new_openssl_ldc = []
+flag_new_openssl_dmd = []
+if ssl_dep.version().version_compare('>=1.1')
+    flag_new_openssl_ldc = '-d-version=VibeUseOpenSSL11'
+    flag_new_openssl_dmd = '-version=VibeUseOpenSSL11'
+endif
+
+if meson.get_compiler('d').get_id() == 'llvm'
+    add_global_arguments(['-d-version=VibeLibeventDriver',
+                          '-d-version=Have_openssl',
+                          '-d-version=Have_diet_ng',
+                          flag_new_openssl_ldc], language : 'd')
+endif
+if meson.get_compiler('d').get_id() == 'dmd'
+    add_global_arguments(['-version=VibeLibeventDriver',
+                          '-version=Have_openssl',
+                          '-version=Have_diet_ng',
+                          flag_new_openssl_dmd], language : 'd')
+endif
+if meson.get_compiler('d').get_id() == 'gnu'
+    error('Vibe.d can not be compiled with GDC at time (2016). Sorry.')
+endif
+
+#
+# D dependencies
+#
+
+# we need to search for this dependency after setting global compiler flags, because
+# it may pull in a subproject after which setting global flags is not allowed anymore
+diet_dep = dependency('diet', fallback: ['diet', 'diet_dep'])
+
 # directory where the external dependencies are included from.
 # Meson will search for this dir in both build_root and source_root
-external_subprojects_dir = 'lib/subprojects'
+subproject_dir = 'lib/subprojects'
 
 # Try to find system OpenSSL bindings, if not found, download
 # a Git copy.
@@ -32,7 +67,7 @@ openssl_src_dir = ''
 if run_command('[', '-d', '/usr/include/d/common/deimos/openssl/', ']').returncode() == 0
     openssl_src_dir = '/usr/include/d/common'
 else
-    openssl_src_dir = external_subprojects_dir + '/openssl'
+    openssl_src_dir = subproject_dir + '/openssl'
     if run_command('[', '-d', openssl_src_dir, ']').returncode() != 0
         message('Fetching OpenSSL D bindings from Github...')
         git_get_requests = run_command(['git', 'clone', 'https://github.com/s-ludwig/openssl.git', openssl_src_dir])
@@ -51,7 +86,7 @@ libevent_src_dir = ''
 if run_command('[', '-d', '/usr/include/d/common/deimos/event2/', ']').returncode() == 0
     libevent_src_dir = '/usr/include/d/common'
 else
-    libevent_src_dir = external_subprojects_dir + '/libevent'
+    libevent_src_dir = subproject_dir + '/libevent'
     if run_command('[', '-d', libevent_src_dir, ']').returncode() != 0
         message('Fetching LibEvent bindings from Github...')
         git_get_requests = run_command(['git', 'clone', 'https://github.com/s-ludwig/libevent.git', libevent_src_dir])
@@ -63,30 +98,6 @@ else
     message('Using non-system LibEvent D bindings.')
 endif
 libevent_inc = include_directories(libevent_src_dir)
-
-#
-# Compiler flags
-#
-flag_new_openssl_ldc = []
-flag_new_openssl_dmd = []
-if ssl_dep.version().version_compare('>=1.1')
-    flag_new_openssl_ldc = '-d-version=VibeUseOpenSSL11'
-    flag_new_openssl_dmd = '-version=VibeUseOpenSSL11'
-endif
-
-if meson.get_compiler('d').get_id() == 'llvm'
-    add_global_arguments(['-d-version=VibeLibeventDriver',
-                          '-d-version=Have_openssl',
-                          flag_new_openssl_ldc], language : 'd')
-endif
-if meson.get_compiler('d').get_id() == 'dmd'
-    add_global_arguments(['-version=VibeLibeventDriver',
-                          '-version=Have_openssl',
-                          flag_new_openssl_dmd], language : 'd')
-endif
-if meson.get_compiler('d').get_id() == 'gnu'
-    error('Vibe.d can not be compiled with GDC at time (2016). Sorry.')
-endif
 
 #
 # Modules

--- a/web/meson.build
+++ b/web/meson.build
@@ -48,7 +48,8 @@ vibe_web_lib = library('vibe-web',
         install: true,
         link_with: [web_link_with],
         dependencies: [crypto_dep,
-                       ssl_dep],
+                       ssl_dep,
+                       diet_dep],
         version: project_version,
         soversion: project_soversion
 )
@@ -56,6 +57,7 @@ pkgc.generate(name: 'vibe-web',
               libraries: [vibe_web_lib] + web_link_with,
               subdirs: 'd/vibe',
               version: project_version,
+              requires: 'diet',
               description: 'High level web and REST service framework'
 )
 
@@ -77,7 +79,8 @@ vibe_test_web_exe = executable('vibe-test_web',
     dependencies: [zlib_dep,
                    crypto_dep,
                    ssl_dep,
-                   libevent_dep],
+                   libevent_dep,
+                   diet_dep],
     link_with: [web_link_with],
     d_args: meson.get_compiler('d').unittest_args(),
     link_args: '-main'


### PR DESCRIPTION
Hi!
This makes the Meson build-system automatically fetch the latest Git copy of Diet in case no Diet is found on the system already. This resolves issue #1898

Please do not merge this until https://github.com/rejectedsoftware/diet-ng/pull/39 is merged and I have adjusted the Git URL in this patch to point to upstream Diet instead of my forked copy!