### PR TITLE
Fix it so that std.c.* is no longer required.

### DIFF
--- a/core/vibe/core/drivers/libevent2.d
+++ b/core/vibe/core/drivers/libevent2.d
@@ -61,10 +61,31 @@ version(Windows)
 
 version(OSX)
 {
-	import std.c.osx.socket : IP_ADD_MEMBERSHIP, IP_MULTICAST_LOOP;
-} else version(Posix)
+	static if (__VERSION__ < 2077)
+	{
+		enum IP_ADD_MEMBERSHIP = 12;
+		enum IP_MULTICAST_LOOP = 11;
+	}
+	else
+		import core.sys.darwin.netinet.in_ : IP_ADD_MEMBERSHIP, IP_MULTICAST_LOOP;
+} else version(FreeBSD)
 {
-    import std.c.linux.socket : IP_ADD_MEMBERSHIP, IP_MULTICAST_LOOP;
+	static if (__VERSION__ < 2077)
+	{
+		enum IP_ADD_MEMBERSHIP  = 12;
+		enum IP_MULTICAST_LOOP  = 11;
+	}
+	else
+		import core.sys.freebsd.netinet.in_ : IP_ADD_MEMBERSHIP, IP_MULTICAST_LOOP;
+} else version(linux)
+{
+	static if (__VERSION__ < 2077)
+	{
+		enum IP_ADD_MEMBERSHIP =  35;
+		enum IP_MULTICAST_LOOP =  34;
+	}
+	else
+		import core.sys.linux.netinet.in_ : IP_ADD_MEMBERSHIP, IP_MULTICAST_LOOP;
 } else version(Windows)
 {
 	// IP_ADD_MEMBERSHIP and IP_MULTICAST_LOOP are included in winsock(2) import above


### PR DESCRIPTION
std.c.* has been deprecated for a while and is about to be removed from
Phobos. The bindings that vibe.d was using that were there and still
missing from druntime have been added, and vibe.d needs to be updated to
use them.

I would have just continued to import `std.c.*.socket` for older versions, but unfortunately, at the moment, it looks like the way that `__VERSION__` is handled in dmd master is that it matches the last major release and not the release that it will be for. The druntime bindings did not quite manage to make it into 2.076 unfortunately, and the `std.c.*` modules were actually scheduled to be removed back in June. So, they probably won't be in master much longer. So, using them as long as `__VERSION__` is less than 2077 will fail thanks to the fact that `__VERSION__` is 2076 for master instead of 2077. So, it made more sense to me to just add the declarations here for now, and once vibe.d no longer supports any versions older than 2.077, then those `static if` blocks can be removed.

Either way, vibe.d needs to stop importing from deprecated modules that are about to be removed. Presumably, it's still been using them, because the necessary bindings weren't in druntime like they were supposed to be, but they are now.