### PR TITLE
meson: Fix typo

### DIFF
--- a/inet/meson.build
+++ b/inet/meson.build
@@ -39,7 +39,7 @@ vibe_inet_lib = library('vibe-inet',
         version: project_version,
         soversion: project_soversion
 )
-pkgc.generate(name: 'vibe-textfilter',
+pkgc.generate(name: 'vibe-inet',
               libraries: [vibe_inet_lib] + inet_link_with,
               subdirs: 'd/vibe',
               version: project_version,


### PR DESCRIPTION
This resolves a stupid copy&paste issue that resulted in a wrong/misnamed pkg-config file being generated and installed.