### PR TITLE
Reduce compile time

### DIFF
--- a/mongodb/vibe/db/mongo/connection.d
+++ b/mongodb/vibe/db/mongo/connection.d
@@ -1164,7 +1164,12 @@ private string getHostArchitecture()
 	else
 		string arch = "unknown ";
 
-	return arch ~ os.endian.to!string;
+	static if(os.endian == os.Endian.bigEndian)
+		string endian = "bigEndian";
+	else static if(os.endian == os.Endian.littleEndian)
+		string endian = "littleEndian";
+
+	return arch ~ endian;
 }
 
 private static immutable hostArchitecture = getHostArchitecture;


### PR DESCRIPTION
As the Endian enum only contains two members doing a static if compiles a lot faster than call std.conv.to on the enum at CT.

Compare the uploads trace_base and trace. It reduces the compile time by about 10ms from 435 to 425 ms.

[trace.json](https://github.com/user-attachments/files/21578334/trace.json)
[trace_base.json](https://github.com/user-attachments/files/21578335/trace_base.json)
