### PR TITLE
chore(rest): Deprecate old-style {query,body,header}Param

### DIFF
--- a/examples/rest/source/app.d
+++ b/examples/rest/source/app.d
@@ -353,11 +353,11 @@ unittest
  * - body for POST requests;
  *
  * This is configurable by means of:
- * - @headerParam : Get a parameter from the query header;
- * - @queryParam : Get a parameter from the query URL;
- * - @bodyParam : Get a parameter from the body;
+ * - @viaHeader : Get a parameter from the query header;
+ * - @viaQuery : Get a parameter from the query URL;
+ * - @viaBody : Get a parameter from the body;
  *
- * In addition, @headerParam have a special handling of 'out' and
+ * In addition, @viaHeader have a special handling of 'out' and
  * 'ref' parameters:
  * - 'out' are neither send by the client nor read by the server, but
  *	their value (except for null string) is returned by the server.
@@ -367,36 +367,31 @@ unittest
  * However, it makes no sense to have 'ref' or 'out' parameters on
  * body or query parameter, so those are treated as error at compile time.
  *
- * If no Json fieldname is passed to @bodyParam, the entire Json body is deserialized into the respective field.
+ * If no Json fieldname is passed to @viaBody, the entire Json body is deserialized into the respective field.
  */
 @rootPathFromName
 interface Example6API
 {
 	@safe:
-	// The first parameter of @headerParam is the identifier (must match one of the parameter name).
-	// The second is the name of the field in the header, such as "Accept", "Content-Type", "User-Agent"...
-	@headerParam("auth", "Authorization")
-	@headerParam("tester", "X-Custom-Tester")
-	@headerParam("www", "WWW-Authenticate")
-	string getPortal(string auth,
-					 ref string tester,
-					 out Nullable!string www);
+	// The parameter to `viaHeader` is the name of the field in the header,
+	// such as "Accept", "Content-Type", "User-Agent"...
+	string getPortal(@viaHeader("Authorization") string auth,
+		@viaHeader("X-Custom-Tester") ref string tester,
+		@viaHeader("WWW-Authenticate") out Nullable!string www);
 
-	// As with @headerParam, the first parameter of @queryParam is the identifier.
-	// The second being the field name, e.g for a query such as: 'GET /root/node?foo=bar', "foo" will be the second parameter.
-	@queryParam("fortyTwo", "qparam")
-	string postAnswer(string fortyTwo);
-	// Finally, there is @bodyParam. It works as you expect it to work,
+	// The parameter is the field name, e.g for a query such as:
+	// 'GET /root/node?foo=bar', "foo" will be the second parameter.
+	string postAnswer(@viaQuery("qparam") string fortyTwo);
+
+	// Finally, there is @viaBody. It works as you expect it to work,
 	// currently serializing passed data as Json and pass them through the body.
-	@bodyParam("myFoo", "parameter")
-	string postConcat(FooType myFoo);
+	string postConcat(@viaBody("parameter") FooType myFoo);
 
-	// If no field name is passed to @bodyParam the entire json object is
+	// If no field name is passed to @viaBody the entire json object is
 	// serialized into the parameter.
 	// Moreover if only one bodyParameter is present, this is the default
 	// behavior.
-	@bodyParam("obj")
-	string postConcatBody(FooType obj);
+	string postConcatBody(@viaBody() FooType obj);
 
 	struct FooType {
 		int a;

--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -361,11 +361,11 @@ unittest
  * - body for POST requests;
  *
  * This is configurable by means of:
- * - @headerParam : Get a parameter from the query header;
- * - @queryParam : Get a parameter from the query URL;
- * - @bodyParam : Get a parameter from the body;
+ * - @viaHeader : Get a parameter from the query header;
+ * - @viaQuery : Get a parameter from the query URL;
+ * - @viaBody : Get a parameter from the body;
  *
- * In addition, @headerParam have a special handling of 'out' and
+ * In addition, @viaHeader have a special handling of 'out' and
  * 'ref' parameters:
  * - 'out' are neither send by the client nor read by the server, but
  *	their value (except for null string) is returned by the server.
@@ -374,26 +374,31 @@ unittest
  * This is to be consistent with the way D 'out' and 'ref' works.
  * However, it makes no sense to have 'ref' or 'out' parameters on
  * body or query parameter, so those are treated as error at compile time.
+ *
+ * If no Json fieldname is passed to @viaBody, the entire Json body is deserialized into the respective field.
  */
 @rootPathFromName
 interface Example6API
 {
 	@safe:
-
-	// The parameter is the name of the field in the header,
+	// The parameter to `viaHeader` is the name of the field in the header,
 	// such as "Accept", "Content-Type", "User-Agent"...
 	string getPortal(@viaHeader("Authorization") string auth,
-					 @viaHeader("X-Custom-Tester") ref string tester,
-					 @viaHeader("WWW-Authenticate") out Nullable!string www);
+		@viaHeader("X-Custom-Tester") ref string tester,
+		@viaHeader("WWW-Authenticate") out Nullable!string www);
 
 	// The parameter is the field name, e.g for a query such as:
-	// 'GET /root/node?foo=bar', it will be "foo".
+	// 'GET /root/node?foo=bar', "foo" will be the second parameter.
 	string postAnswer(@viaQuery("qparam") string fortyTwo);
-	// Finally, there is `@viaBody`. It works as you expect it to work,
+
+	// Finally, there is @viaBody. It works as you expect it to work,
 	// currently serializing passed data as Json and pass them through the body.
 	string postConcat(@viaBody("parameter") FooType myFoo);
 
-	// Without a parameter, it will represent the entire body
+	// If no field name is passed to @viaBody the entire json object is
+	// serialized into the parameter.
+	// Moreover if only one bodyParameter is present, this is the default
+	// behavior.
 	string postConcatBody(@viaBody() FooType obj);
 
 	int testStatus(@viaStatus out int status, @viaStatus out string status_phrase);

--- a/web/vibe/web/common.d
+++ b/web/vibe/web/common.d
@@ -707,7 +707,7 @@ public struct WebParamAttribute {
  * `viaBody` should be applied to the parameter itself, while `bodyParam`
  * is applied to the function.
  * `bodyParam` was introduced long before the D language for UDAs on parameters
- * (introduced in DMD v2.082.0), and will be deprecated in a future release.
+ * (introduced in DMD v2.082.0), and is deprecated.
  *
  * Params:
  *   identifier = The name of the parameter to customize. A compiler error will be issued on mismatch.
@@ -727,6 +727,7 @@ WebParamAttribute viaBody(string field = null)
 }
 
 /// Ditto
+deprecated("Use `viaBody` directly on the parameter instead")
 WebParamAttribute bodyParam(string identifier, string field) @safe
 in {
 	assert(field.length > 0, "fieldname can't be empty.");
@@ -739,6 +740,7 @@ do
 }
 
 /// ditto
+deprecated("Use `viaBody` directly on the parameter instead")
 WebParamAttribute bodyParam(string identifier)
 @safe {
 	if (!__ctfe)
@@ -757,7 +759,7 @@ WebParamAttribute bodyParam(string identifier)
  * `viaHeader` should be applied to the parameter itself, while `headerParam`
  * is applied to the function.
  * `headerParam` was introduced long before the D language for UDAs on parameters
- * (introduced in DMD v2.082.0), and will be deprecated in a future release.
+ * (introduced in DMD v2.082.0), and is deprecated.
  *
  * Params:
  *   identifier = The name of the parameter to customize. A compiler error will be issued on mismatch.
@@ -776,6 +778,7 @@ WebParamAttribute viaHeader(string field)
 }
 
 /// Ditto
+deprecated("Use `viaHeader` directly on the parameter instead")
 WebParamAttribute headerParam(string identifier, string field)
 @safe {
 	if (!__ctfe)
@@ -793,7 +796,7 @@ WebParamAttribute headerParam(string identifier, string field)
  * `viaQuery` should be applied to the parameter itself, while `queryParam`
  * is applied to the function.
  * `queryParam` was introduced long before the D language for UDAs on parameters
- * (introduced in DMD v2.082.0), and will be deprecated in a future release.
+ * (introduced in DMD v2.082.0), and is deprecated.
  *
  * Params:
  *   identifier = The name of the parameter to customize. A compiler error will be issued on mismatch.
@@ -813,6 +816,7 @@ WebParamAttribute viaQuery(string field)
 }
 
 /// Ditto
+deprecated("Use `viaQuery` directly on the parameter instead")
 WebParamAttribute queryParam(string identifier, string field)
 @safe {
 	if (!__ctfe)

--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -2626,7 +2626,7 @@ unittest {
 }
 
 // Reject unattributed / @queryParam or @bodyParam ref / out parameters
-unittest {
+deprecated unittest {
 	interface QueryRef {
 		@queryParam("auth", "auth")
 		string getData(ref string auth);


### PR DESCRIPTION
They were introduced at a time when D didn't have support for parameter UDA, which is long gone, and we should recommend people using the 'via' alternative instead as they are properly tied to the parameter.