### PR TITLE
feat(rest): Provide more information on error

### DIFF
--- a/tests/vibe.web.rest.error/dub.sdl
+++ b/tests/vibe.web.rest.error/dub.sdl
@@ -1,0 +1,2 @@
+name "vibe-web-rest-error-test"
+dependency "vibe-d:web" path="../../"

--- a/tests/vibe.web.rest.error/source/app.d
+++ b/tests/vibe.web.rest.error/source/app.d
@@ -1,0 +1,87 @@
+import std;
+import vibe.core.core;
+import vibe.core.stream;
+import vibe.data.bson;
+import vibe.data.json;
+import vibe.data.serialization;
+import vibe.http.client;
+import vibe.http.router;
+import vibe.http.server;
+import vibe.stream.memory;
+import vibe.stream.operations;
+import vibe.web.rest;
+
+void main()
+@safe {
+	auto settings = new HTTPServerSettings;
+	settings.port = 0;
+	settings.bindAddresses = ["127.0.0.1"];
+	auto router = new URLRouter;
+    router.registerRestInterface(new Server);
+    router.post("/api/error1", &handleError1);
+    router.post("/api/error2", &handleError2);
+	auto listener = listenHTTP(settings, router);
+	scope (exit) listener.stopListening();
+	immutable addr = listener.bindAddresses[0];
+
+	auto api = new RestInterfaceClient!API("http://"~addr.toString);
+
+    // Test that regular exception lead to JSON error
+    try {
+        api.getError();
+        assert(0);
+    } catch (RestException exc) {
+        assert(exc.message() == "Something very bad happened");
+        assert(exc.jsonResult["statusDebugMessage"].get!string.canFind("object.Exception@source"));
+    }
+
+    // Test that `text/plain` is properly handled
+    try {
+        api.postError1();
+        assert(0);
+    } catch (RestException exc)
+        assert(exc.message() == "No name was provided");
+
+    // Test that no content-type is properly handled
+    try {
+        api.postError2();
+        assert(0);
+    } catch (RestException exc) {
+        debug writeln(exc.jsonResult);
+        assert(exc.message() == "Internal Server Error");
+        // Base64 encoding of 'Invalid name'
+        assert(exc.jsonResult["data"].get!string == "SW52YWxpZCBuYW1lCg==");
+    }
+}
+
+@path("/api")
+interface ServerAPI {
+@safe:
+    string getError();
+}
+
+@path("/api")
+interface API : ServerAPI {
+    @safe:
+    string postError1();
+    string postError2();
+}
+
+// We split the API because `Server` shouldn't implement `postError` - we need
+// to control exactly how the response is sent for the test to be useful.
+class Server : ServerAPI {
+    string getError() {
+        throw new Exception("Something very bad happened");
+    }
+}
+
+private void handleError1 (scope HTTPServerRequest req, scope HTTPServerResponse res) @safe {
+    assert(req.method == HTTPMethod.POST, "Unexpected method");
+    res.writeBody("No name was provided", 400, "text/plain");
+}
+
+private void handleError2 (scope HTTPServerRequest req, scope HTTPServerResponse res) @safe {
+    assert(req.method == HTTPMethod.POST, "Unexpected method");
+    res.headers["Content-Type"] = null;
+    res.writeBody("Invalid name\n", 500);
+}

--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -2107,11 +2107,23 @@ private HTTPClientResponse request(URL base_url,
 
 	if (!isSuccessCode(cast(HTTPStatus)client_res.statusCode))
 	{
-		Json msg = Json(["statusMessage": Json(client_res.statusPhrase)]);
-		if (client_res.contentType.length)
-			if (client_res.contentType.splitter(";").front.strip.sicmp("application/json") == 0)
-				msg = client_res.readJson();
-		client_res.dropBody();
+		import std.base64;
+
+		Json msg;
+		auto ctypeR = client_res.contentType.splitter(";");
+		const ctype = ctypeR.empty ? string.init : ctypeR.front.strip;
+		if (ctype.sicmp("application/json") == 0)
+			msg = client_res.readJson();
+		else if (ctype.sicmp("text/plain") == 0)
+			msg = Json(["statusMessage": Json(client_res.bodyReader.readAllUTF8())]);
+		else {
+			msg = Json(["statusMessage": Json(client_res.statusPhrase)]);
+			if (client_res.contentType.length)
+				msg["contentType"] = Json(client_res.contentType);
+			ubyte[] data = client_res.bodyReader.readAll();
+			if (data.length)
+				msg["data"] = Base64.encode(data);
+		}
 		throw new RestException(client_res.statusCode, msg);
 	}
 


### PR DESCRIPTION
I have a use case with an API (Nomad) that doesn't set any Content-Type on error, returns a 500 (for something that should be 400), and leads to a very user-unfriendly experience when using the tool. This should provide better out-of-the-box experience for vibe.web.rest user, by recognizing 'text/plain' messages, and otherwise encoding the binary data so the caller may be able to do something with it.