### PR TITLE
[redis] Avoid rvalue struct assign

### DIFF
--- a/redis/vibe/db/redis/idioms.d
+++ b/redis/vibe/db/redis/idioms.d
@@ -71,7 +71,10 @@ struct RedisCollection(T /*: RedisValue*/, RedisCollectionOptions OPTIONS = Redi
 		IDType add(U)(U args)
 		{
 			auto id = createID();
-			this[id] = args;
+			static if (__traits(compiles, this.opIndexAssign))
+				this[id] = args;
+			else
+				this[id].opAssign(args); // workaround rvalue struct assign error
 			return id;
 		}
 


### PR DESCRIPTION
I'm trying to make assigning to a struct rvalue a compiler error, because often the assignment is silently thrown away:
https://github.com/dlang/dmd/pull/21717#issuecomment-3191656768

That PR breaks some buildkite projects, including this one - so it will probably be a deprecation/error in an edition. This PR makes this project compatible.

Call `opAssign` directly instead, which is allowed by the spec:

> an instance method can still be called on an rvalue struct instance,
even if the method is not const

https://dlang.org/spec/struct.html#member-functions

__Disclaimer:__ I'm not sure if this is a suitable solution for this project, as I'm not familiar with it. From running `dub test`, it appears to work without triggering the new dmd error.