### PR TITLE
Fix and Example how to return binary data with Content-Type

### DIFF
--- a/tests/rest/source/app.d
+++ b/tests/rest/source/app.d
@@ -8,6 +8,7 @@ import vibe.appmain;
 import vibe.core.core;
 import vibe.core.log;
 import vibe.core.stream : InputStreamProxy;
+import vibe.stream.memory;
 import vibe.data.json;
 import vibe.http.router;
 import vibe.http.server;
@@ -562,6 +563,34 @@ class Example8 : Example8API
 	}
 }
 
+/* --------- EXAMPLE 9 ---------- */
+
+/*
+ * This example shows how to return data from a rest endpoint and setting the
+ * Content-Type. If and only if the return type is a vibe.d InputStream, which
+ * MemoryStream is, assigning the Content-Type via out variable will work.
+ */
+@rootPathFromName
+interface Example9API
+{
+	@safe:
+
+	// The parameter is the name of the field in the header,
+	MemoryStream getImage(out @viaHeader("Content-Type") string contentType);
+}
+
+class Example9 : Example9API
+{
+override:
+	MemoryStream getImage(out string contentType)
+	{
+		contentType = "image/jpeg";
+		return () @trusted {
+			return createMemoryStream(cast(ubyte[])"Hello World", false);
+		}();
+	}
+}
+
 unittest
 {
 	auto router = new URLRouter;
@@ -749,6 +778,17 @@ void runTests(string url)
 		assert(api.getEnum(Example8API.E.bar) == Example8API.E.foo);
 		assert(api.getEnum(Example8API.E.baz) == Example8API.E.bar);
 	}
+
+	// Example 9
+	{
+		import vibe.http.client : requestHTTP;
+
+		auto res = requestHTTP(url ~ "/example9_api/image");
+		assert(res.statusCode == 200);
+		string rslt = res.bodyReader.readAllUTF8();
+		assert(rslt == "Hello World", rslt);
+		assert(res.headers["Content-Type"] == "image/jpeg", res.headers["Content-Type"]);
+	}
 }
 
 shared static this()
@@ -765,6 +805,7 @@ shared static this()
 	registerRestInterface(routes, new Example6());
 	registerRestInterface(routes, new Example7());
 	registerRestInterface(routes, new Example8());
+	registerRestInterface(routes, new Example9());
 
 	auto settings = new HTTPServerSettings();
 	settings.port = 0;

--- a/web/vibe/web/rest.d
+++ b/web/vibe/web/rest.d
@@ -1653,10 +1653,10 @@ private HTTPServerRequestDelegate jsonMethodHandler(alias Func, size_t ridx, T)(
 				returnHeaders();
 				res.writeBody(cast(ubyte[])null);
 			} else static if (isInputStream!RT) {
-				returnHeaders();
 				auto ret = evaluateOutputModifiers!CFunc(
 						__traits(getMember, inst, Method)(params), req, res);
-				res.headers["Content-Type"] = "application/octet-stream";
+				returnHeaders();
+				res.headers["Content-Type"] = res.headers.get("Content-Type", "application/octet-stream");
 				ret.pipe(res.bodyWriter);
 			} else {
 				// TODO: remove after deprecation period


### PR DESCRIPTION
While looking into how to return a image from a REST api, I tried using the viaHeader out parameter to assign the Content-Type.

This didn't work, as the DefaultSerializer sets the Content-Type always to "application/json". Defining a custom Serializer doesn't work as it only allows a single Content-Type and images can have multiple. Returning an InputStream does bypass the DefaultSerializer, but the Content-Type set via the out parameter still failed. The fix was the to change the order of the
* evaluateOutputModifiers
* returnHeaders calls, making them similar to the other code paths. The example shows how to set the Content-Type and return a stream.