### PR TITLE
Fix estimatedDocumentCount crash on non-existent collections

### DIFF
--- a/mongodb/vibe/db/mongo/collection.d
+++ b/mongodb/vibe/db/mongo/collection.d
@@ -836,8 +836,15 @@ struct MongoCollection {
 			AggregateOptions aggOptions;
 			aggOptions.maxTimeMS = options.maxTimeMS;
 			aggOptions.readConcern = options.readConcern;
-			auto reply = aggregate(pipeline, aggOptions).front;
-			return reply["n"].to!long;
+
+			try {
+				auto reply = aggregate(pipeline, aggOptions).front;
+				return reply["n"].to!long;
+			} catch (MongoDriverException) {
+				// $collStats fails when the collection does not exist.
+				// Match the behavior of the mongo shell which returns 0.
+				return 0;
+			}
 		} else {
 			return countImpl(null, options.readConcern);
 		}


### PR DESCRIPTION
The $collStats aggregation pipeline used by estimatedDocumentCount throws a MongoDriverException when the collection does not exist in the database. This causes repeated errors in applications that register collections before they are created. The fix catches the exception and returns 0, matching the behavior of MongoDB's shell estimatedDocumentCount() on missing collections.